### PR TITLE
translateTime accept an optional format string

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -48,10 +48,10 @@ error like objects. Default: `err,error`.
 + `--messageKey` (`-m`): Define the key that contains the main log message.
 Default: `msg`.
 + `--translateTime` (`-t`): Translate the epoch time value into a human readable
-in `UTC`. The default pattern is `'yyyy-mm-dd HH:MM:ss.l o'` time in UTC.
-IF want to translate to the local system's timezone, require `SYS:` prefix at 
-input format string. For a list of available pattern letters see the 
-[`dateformat` documentation](https://www.npmjs.com/package/dateformat#mask-options).
+date and time string in `UTC`. The default pattern is `'yyyy-mm-dd HH:MM:ss.l o'`.
+If you want to translate to the local system's timezone, then you must prefix the format 
+string with `SYS:`, e.g. `'SYS:yyyy-mm-dd HH:MM:ss'`. See [`dateformat` documentation](https://www.npmjs.com/package/dateformat#mask-options)
+for more available pattern letters.
 
 <a id="api"></a>
 ## API

--- a/Readme.md
+++ b/Readme.md
@@ -47,13 +47,13 @@ of properties. The list should be a comma separated list of properties Default: 
 error like objects. Default: `err,error`.
 + `--messageKey` (`-m`): Define the key that contains the main log message.
 Default: `msg`.
-+ `--systemTime` (`-n`): When translating the time to a human readable format,
++ `--systemZone` (`-s`): When translating the time to a human readable format,
 use the system timezone for displaying the time. See `--translateTime` for more
 information on the output format.
 + `--translateTime` (`-t`): Translate the epoch time value into a human readable
 UTC date and time string. The default format string is `'yyyy-mm-dd HH:MM:ss.l o'`.
-For a list of available patter letters see the 
-[`dateformat` documentation](https://www.npmjs.com/package/dateformat).
+For a list of available pattern letters see the 
+[`dateformat` documentation](https://www.npmjs.com/package/dateformat#mask-options).
 
 <a id="api"></a>
 ## API
@@ -69,7 +69,7 @@ in [CLI Arguments](#cliargs):
   errorLikeObjectKeys: ['err', 'error'], // --errorLikeObjectKeys
   errorProps: '', // --errorProps
   levelFirst: false, // --levelFirst
-  systemTime: false, // --systemTime
+  systemTime: false, // --systemZone
   messageKey: 'msg', // --messageKey
   translateTime: false // --translateTime
 }

--- a/Readme.md
+++ b/Readme.md
@@ -47,12 +47,10 @@ of properties. The list should be a comma separated list of properties Default: 
 error like objects. Default: `err,error`.
 + `--messageKey` (`-m`): Define the key that contains the main log message.
 Default: `msg`.
-+ `--systemZone` (`-s`): When translating the time to a human readable format,
-use the system timezone for displaying the time. See `--translateTime` for more
-information on the output format.
 + `--translateTime` (`-t`): Translate the epoch time value into a human readable
-UTC date and time string. The default format string is `'yyyy-mm-dd HH:MM:ss.l o'`.
-For a list of available pattern letters see the 
+in `UTC`. The default pattern is `'yyyy-mm-dd HH:MM:ss.l o'` time in UTC.
+IF want to translate to the local system's timezone, require `SYS:` prefix at 
+input format string. For a list of available pattern letters see the 
 [`dateformat` documentation](https://www.npmjs.com/package/dateformat#mask-options).
 
 <a id="api"></a>
@@ -69,7 +67,6 @@ in [CLI Arguments](#cliargs):
   errorLikeObjectKeys: ['err', 'error'], // --errorLikeObjectKeys
   errorProps: '', // --errorProps
   levelFirst: false, // --levelFirst
-  systemTime: false, // --systemZone
   messageKey: 'msg', // --messageKey
   translateTime: false // --translateTime
 }

--- a/Readme.md
+++ b/Readme.md
@@ -40,12 +40,6 @@ $ npm install -g pino-pretty
 + `--colorize` (`-c`): Adds terminal color escape sequences to the output.
 + `--crlf` (`-f`): Appends carriage return and line feed, instead of just a line
 feed, to the formatted log line.
-+ `--dateFormat` (`-d`): Sets the format string to apply when translating the date
-to human readable format (see: `--translateTime`). The default format string
-is `'yyyy-mm-dd HH:MM:ss.l o'`. For a list of available patter letters
-see the [`dateformat` documentation](https://www.npmjs.com/package/dateformat).
-When the value is anything other than the default value, `--translateTime` is
-implied.
 + `--errorProps` (`-e`): When formatting an error object, display this list
 of properties. The list should be a comma separated list of properties Default: `''`.
 + `--levelFirst` (`-l`): Display the log level name before the logged date and time.
@@ -53,10 +47,13 @@ of properties. The list should be a comma separated list of properties Default: 
 error like objects. Default: `err,error`.
 + `--messageKey` (`-m`): Define the key that contains the main log message.
 Default: `msg`.
-+ `--localTime` (`-n`): When translating the time to a human readable format,
-use the system timezone for displaying the time.
++ `--systemTime` (`-n`): When translating the time to a human readable format,
+use the system timezone for displaying the time. See `--translateTime` for more
+information on the output format.
 + `--translateTime` (`-t`): Translate the epoch time value into a human readable
-date and time string. See `--dateFormat` for information on the output format.
+UTC date and time string. The default format string is `'yyyy-mm-dd HH:MM:ss.l o'`.
+For a list of available patter letters see the 
+[`dateformat` documentation](https://www.npmjs.com/package/dateformat).
 
 <a id="api"></a>
 ## API
@@ -69,11 +66,10 @@ in [CLI Arguments](#cliargs):
 {
   colorize: false, // --colorize
   crlf: false, // --crlf
-  dateFormat: 'yyyy-mm-dd HH:MM:ss.l o', // --dateFormat
   errorLikeObjectKeys: ['err', 'error'], // --errorLikeObjectKeys
   errorProps: '', // --errorProps
   levelFirst: false, // --levelFirst
-  localTime: false, // --localTime
+  systemTime: false, // --systemTime
   messageKey: 'msg', // --messageKey
   translateTime: false // --translateTime
 }

--- a/bin.js
+++ b/bin.js
@@ -15,13 +15,14 @@ args
   .option(['l', 'levelFirst'], 'Display the log level as the first output field')
   .option(['k', 'errorLikeObjectKeys'], 'Define which keys contain error objects (`-k err,error`)', 'err,error')
   .option(['m', 'messageKey'], 'Highlight the message under the specified key', CONSTANTS.MESSAGE_KEY)
-  .option(['n', 'systemTime'], 'Convert Epoch timestamps to custom systemTimeZone format (defaults to ISO 8601)')
-  .option(['t', 'translateTime'], 'Convert Epoch timestamps to custom UTC format (defaults to ISO 8601)')
+  .option(['s', 'systemZone'], 'Display epoch timestamps as systemZone-based format (defaults to ISO 8601)')
+  .option(['t', 'translateTime'], 'Display epoch timestamps as UTC-based custom format (defaults to ISO 8601)')
 
 args
   .example('cat log | pino-pretty', 'To prettify logs, simply pipe a log file through')
   .example('cat log | pino-pretty -m fooMessage', 'To highlight a string at a key other than \'msg\', use')
   .example('cat log | pino-pretty -t', 'To convert Epoch timestamps to ISO timestamps use the -t option')
+  .example('cat log | pino-pretty -t [dateString]', 'To convert Epoch timestamps to UTC custom timestamps use the -t option [with custom dateString]')
   .example('cat log | pino-pretty -l', 'To flip level and time/date in standard output use the -l option')
 
 const opts = args.parse(process.argv)

--- a/bin.js
+++ b/bin.js
@@ -15,14 +15,13 @@ args
   .option(['l', 'levelFirst'], 'Display the log level as the first output field')
   .option(['k', 'errorLikeObjectKeys'], 'Define which keys contain error objects (`-k err,error`)', 'err,error')
   .option(['m', 'messageKey'], 'Highlight the message under the specified key', CONSTANTS.MESSAGE_KEY)
-  .option(['s', 'systemZone'], 'Display epoch timestamps as systemZone-based format (defaults to ISO 8601)')
-  .option(['t', 'translateTime'], 'Display epoch timestamps as UTC-based custom format (defaults to ISO 8601)')
+  .option(['t', 'translateTime'], 'Display epoch timestamps as UTC ISO format, also accept a formatString to alter the output (default ISO 8601)')
 
 args
   .example('cat log | pino-pretty', 'To prettify logs, simply pipe a log file through')
   .example('cat log | pino-pretty -m fooMessage', 'To highlight a string at a key other than \'msg\', use')
   .example('cat log | pino-pretty -t', 'To convert Epoch timestamps to ISO timestamps use the -t option')
-  .example('cat log | pino-pretty -t [dateString]', 'To convert Epoch timestamps to UTC custom timestamps use the -t option [with custom dateString]')
+  .example('cat log | pino-pretty -t "SYS:formatString"', 'To convert Epoch timestamps to local timezone format use the -t option with SYS:formatString')
   .example('cat log | pino-pretty -l', 'To flip level and time/date in standard output use the -l option')
 
 const opts = args.parse(process.argv)

--- a/bin.js
+++ b/bin.js
@@ -15,8 +15,8 @@ args
   .option(['l', 'levelFirst'], 'Display the log level as the first output field')
   .option(['k', 'errorLikeObjectKeys'], 'Define which keys contain error objects (`-k err,error`)', 'err,error')
   .option(['m', 'messageKey'], 'Highlight the message under the specified key', CONSTANTS.MESSAGE_KEY)
-  .option(['n', 'localTime'], 'Display timestamps according to system timezone')
-  .option(['t', 'translateTime'], 'Convert Epoch timestamps to ISO format')
+  .option(['n', 'systemTime'], 'Convert Epoch timestamps to custom systemTimeZone format (defaults to ISO 8601)')
+  .option(['t', 'translateTime'], 'Convert Epoch timestamps to custom UTC format (defaults to ISO 8601)')
 
 args
   .example('cat log | pino-pretty', 'To prettify logs, simply pipe a log file through')

--- a/bin.js
+++ b/bin.js
@@ -15,13 +15,13 @@ args
   .option(['l', 'levelFirst'], 'Display the log level as the first output field')
   .option(['k', 'errorLikeObjectKeys'], 'Define which keys contain error objects (`-k err,error`)', 'err,error')
   .option(['m', 'messageKey'], 'Highlight the message under the specified key', CONSTANTS.MESSAGE_KEY)
-  .option(['t', 'translateTime'], 'Display epoch timestamps as UTC ISO format, also accept a formatString to alter the output (default ISO 8601)')
+  .option(['t', 'translateTime'], 'Display epoch timestamps as UTC ISO format or according to an optional format string (default ISO 8601)')
 
 args
   .example('cat log | pino-pretty', 'To prettify logs, simply pipe a log file through')
   .example('cat log | pino-pretty -m fooMessage', 'To highlight a string at a key other than \'msg\', use')
   .example('cat log | pino-pretty -t', 'To convert Epoch timestamps to ISO timestamps use the -t option')
-  .example('cat log | pino-pretty -t "SYS:formatString"', 'To convert Epoch timestamps to local timezone format use the -t option with SYS:formatString')
+  .example('cat log | pino-pretty -t "SYS:yyyy-mm-dd HH:MM:ss"', 'To convert Epoch timestamps to local timezone format use the -t option with "SYS:" prefixed format string')
   .example('cat log | pino-pretty -l', 'To flip level and time/date in standard output use the -l option')
 
 const opts = args.parse(process.argv)

--- a/bin.js
+++ b/bin.js
@@ -11,7 +11,6 @@ const CONSTANTS = require('./lib/constants')
 args
   .option(['c', 'colorize'], 'Force adding color sequences to the output')
   .option(['f', 'crlf'], 'Append CRLF instead of LF to formatted lines')
-  .option(['d', 'dateFormat'], 'A format string to govern display of dates. When not set to the default value, `--translateTime` is implied', CONSTANTS.DATE_FORMAT)
   .option(['e', 'errorProps'], 'Comma separated list of properties on error objects to show (`*` for all properties)', '')
   .option(['l', 'levelFirst'], 'Display the log level as the first output field')
   .option(['k', 'errorLikeObjectKeys'], 'Define which keys contain error objects (`-k err,error`)', 'err,error')

--- a/index.js
+++ b/index.js
@@ -56,8 +56,17 @@ module.exports = function prettyFactory (options) {
   const errorLikeObjectKeys = opts.errorLikeObjectKeys
   const errorProps = opts.errorProps.split(',')
 
-  if (opts.dateFormat.length > 0 && opts.dateFormat !== CONSTANTS.DATE_FORMAT) {
+  if (opts.localTime) {
+    if (opts.localTime.length > 0) {
+      opts.dateFormat = opts.localTime
+    }
     opts.translateTime = true
+  }
+
+  if (opts.translateTime) {
+    if (opts.translateTime.length > 0) {
+      opts.dateFormat = opts.translateTime
+    }
   }
 
   const color = {

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const defaultOptions = {
   errorLikeObjectKeys: ['err', 'error'],
   errorProps: '',
   levelFirst: false,
-  systemTime: false,
+  systemZone: false,
   messageKey: CONSTANTS.MESSAGE_KEY,
   translateTime: false,
   useMetadata: false,
@@ -56,16 +56,18 @@ module.exports = function prettyFactory (options) {
   const errorProps = opts.errorProps.split(',')
   let dateString = CONSTANTS.DATE_FORMAT
 
-  if (opts.systemTime) {
-    if (opts.systemTime.length > 0) {
-      dateString = opts.systemTime
-    }
-    opts.translateTime = true
-  }
-
   if (opts.translateTime) {
     if (opts.translateTime.length > 0) {
       dateString = opts.translateTime
+    }
+  }
+
+  if (opts.systemZone) {
+    if (opts.translateTime.length > 0) {
+      dateString = opts.translateTime
+    } else {
+      opts.translateTime = true
+      dateString = CONSTANTS.DATE_FORMAT
     }
   }
 
@@ -118,7 +120,7 @@ module.exports = function prettyFactory (options) {
     ]
 
     if (opts.translateTime) {
-      log.time = formatTime(log.time, dateString, opts.systemTime)
+      log.time = formatTime(log.time, dateString, opts.systemZone)
     }
 
     var line = `[${log.time}]`

--- a/index.js
+++ b/index.js
@@ -19,11 +19,10 @@ const levels = {
 const defaultOptions = {
   colorize: false,
   crlf: false,
-  dateFormat: CONSTANTS.DATE_FORMAT,
   errorLikeObjectKeys: ['err', 'error'],
   errorProps: '',
   levelFirst: false,
-  localTime: false,
+  systemTime: false,
   messageKey: CONSTANTS.MESSAGE_KEY,
   translateTime: false,
   useMetadata: false,
@@ -38,9 +37,9 @@ function isPinoLog (log) {
   return log && (log.hasOwnProperty('v') && log.v === 1)
 }
 
-function formatTime (epoch, formatString, localTime) {
+function formatTime (epoch, formatString, systemTime) {
   const instant = new Date(epoch)
-  if (localTime) return dateformat(instant, formatString)
+  if (systemTime) return dateformat(instant, formatString)
   return dateformat(instant, 'UTC:' + formatString)
 }
 
@@ -55,17 +54,18 @@ module.exports = function prettyFactory (options) {
   const messageKey = opts.messageKey
   const errorLikeObjectKeys = opts.errorLikeObjectKeys
   const errorProps = opts.errorProps.split(',')
+  let dateString = CONSTANTS.DATE_FORMAT
 
-  if (opts.localTime) {
-    if (opts.localTime.length > 0) {
-      opts.dateFormat = opts.localTime
+  if (opts.systemTime) {
+    if (opts.systemTime.length > 0) {
+      dateString = opts.systemTime
     }
     opts.translateTime = true
   }
 
   if (opts.translateTime) {
     if (opts.translateTime.length > 0) {
-      opts.dateFormat = opts.translateTime
+      dateString = opts.translateTime
     }
   }
 
@@ -118,7 +118,7 @@ module.exports = function prettyFactory (options) {
     ]
 
     if (opts.translateTime) {
-      log.time = formatTime(log.time, opts.dateFormat, opts.localTime)
+      log.time = formatTime(log.time, dateString, opts.systemTime)
     }
 
     var line = `[${log.time}]`

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function formatTime (epoch, translateTime) {
     return dateformat(instant, 'UTC:' + CONSTANTS.DATE_FORMAT)
   } else {
     const upperFormat = translateTime.toUpperCase()
-    return (upperFormat.indexOf('SYS:') === -1)
+    return (!upperFormat.startsWith('SYS:'))
       ? dateformat(instant, 'UTC:' + translateTime)
       : (upperFormat === 'SYS:STANDARD')
         ? dateformat(instant, CONSTANTS.DATE_FORMAT)

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -133,7 +133,7 @@ test('basic prettifier tests', (t) => {
 
   t.test('will format date to local time in default ISO format', (t) => {
     t.plan(1)
-    const pretty = prettyFactory({ localTime: true })
+    const pretty = prettyFactory({ systemTime: true })
     const log = pino({}, new Writable({
       write (chunk, enc, cb) {
         const formatted = pretty(chunk.toString())
@@ -152,7 +152,7 @@ test('basic prettifier tests', (t) => {
 
   t.test('will format date to local time in custom format', (t) => {
     t.plan(1)
-    const pretty = prettyFactory({ localTime: 'yyyy/mm/dd HH:MM:ss o' })
+    const pretty = prettyFactory({ systemTime: 'yyyy/mm/dd HH:MM:ss o' })
     const log = pino({}, new Writable({
       write (chunk, enc, cb) {
         const formatted = pretty(chunk.toString())

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -131,9 +131,9 @@ test('basic prettifier tests', (t) => {
     log.info('foo')
   })
 
-  t.test('will format date to local time in default ISO format', (t) => {
+  t.test('will format date to systemZone-based in default ISO 8601 format', (t) => {
     t.plan(1)
-    const pretty = prettyFactory({ systemTime: true })
+    const pretty = prettyFactory({ systemZone: true })
     const log = pino({}, new Writable({
       write (chunk, enc, cb) {
         const formatted = pretty(chunk.toString())
@@ -150,9 +150,12 @@ test('basic prettifier tests', (t) => {
     log.info('foo')
   })
 
-  t.test('will format date to local time in custom format', (t) => {
+  t.test('will format date to systemZone-based time in custom format', (t) => {
     t.plan(1)
-    const pretty = prettyFactory({ systemTime: 'yyyy/mm/dd HH:MM:ss o' })
+    const pretty = prettyFactory({
+      systemZone: true,
+      translateTime: 'yyyy/mm/dd HH:MM:ss o'
+    })
     const log = pino({}, new Writable({
       write (chunk, enc, cb) {
         const formatted = pretty(chunk.toString())

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -97,7 +97,7 @@ test('basic prettifier tests', (t) => {
     log.info({bar: 'baz'})
   })
 
-  t.test('will format date to UTC', (t) => {
+  t.test('will format time to UTC', (t) => {
     t.plan(1)
     const pretty = prettyFactory({translateTime: true})
     const log = pino({}, new Writable({
@@ -113,7 +113,7 @@ test('basic prettifier tests', (t) => {
     log.info('foo')
   })
 
-  t.test('will format date to UTC in custom format', (t) => {
+  t.test('will format time to UTC in custom format', (t) => {
     t.plan(1)
     const pretty = prettyFactory({ translateTime: 'HH:MM:ss o' })
     const log = pino({}, new Writable({
@@ -131,9 +131,9 @@ test('basic prettifier tests', (t) => {
     log.info('foo')
   })
 
-  t.test('will format date to systemZone-based in default ISO 8601 format', (t) => {
+  t.test('will format time to local systemzone in ISO 8601 format', (t) => {
     t.plan(1)
-    const pretty = prettyFactory({ systemZone: true })
+    const pretty = prettyFactory({ translateTime: 'sys:standard' })
     const log = pino({}, new Writable({
       write (chunk, enc, cb) {
         const formatted = pretty(chunk.toString())
@@ -150,11 +150,10 @@ test('basic prettifier tests', (t) => {
     log.info('foo')
   })
 
-  t.test('will format date to systemZone-based time in custom format', (t) => {
+  t.test('will format time to local systemzone in custom format', (t) => {
     t.plan(1)
     const pretty = prettyFactory({
-      systemZone: true,
-      translateTime: 'yyyy/mm/dd HH:MM:ss o'
+      translateTime: 'SYS:yyyy/mm/dd HH:MM:ss o'
     })
     const log = pino({}, new Writable({
       write (chunk, enc, cb) {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -113,12 +113,27 @@ test('basic prettifier tests', (t) => {
     log.info('foo')
   })
 
-  t.test('will format date to local time', (t) => {
+  t.test('will format date to UTC in custom format', (t) => {
     t.plan(1)
-    const pretty = prettyFactory({
-      translateTime: true,
-      localTime: true
-    })
+    const pretty = prettyFactory({ translateTime: 'HH:MM:ss o' })
+    const log = pino({}, new Writable({
+      write (chunk, enc, cb) {
+        const formatted = pretty(chunk.toString())
+        const utcHour = dateformat(epoch, 'UTC:' + 'HH')
+        const offset = dateformat(epoch, 'UTC:' + 'o')
+        t.is(
+          formatted,
+          `[${utcHour}:35:28 ${offset}] INFO (${pid} on ${hostname}): foo\n`
+        )
+        cb()
+      }
+    }))
+    log.info('foo')
+  })
+
+  t.test('will format date to local time in default ISO format', (t) => {
+    t.plan(1)
+    const pretty = prettyFactory({ localTime: true })
     const log = pino({}, new Writable({
       write (chunk, enc, cb) {
         const formatted = pretty(chunk.toString())
@@ -135,15 +150,18 @@ test('basic prettifier tests', (t) => {
     log.info('foo')
   })
 
-  t.test('will format date with a custom format string', (t) => {
+  t.test('will format date to local time in custom format', (t) => {
     t.plan(1)
-    const pretty = prettyFactory({dateFormat: 'yyyy-mm-dd HH:MM'})
+    const pretty = prettyFactory({ localTime: 'yyyy/mm/dd HH:MM:ss o' })
     const log = pino({}, new Writable({
       write (chunk, enc, cb) {
         const formatted = pretty(chunk.toString())
+        const localHour = dateformat(epoch, 'HH')
+        const localDate = dateformat(epoch, 'yyyy/mm/dd')
+        const offset = dateformat(epoch, 'o')
         t.is(
           formatted,
-          `[2018-03-30 17:35] INFO (${pid} on ${hostname}): foo\n`
+          `[${localDate} ${localHour}:35:28 ${offset}] INFO (${pid} on ${hostname}): foo\n`
         )
         cb()
       }


### PR DESCRIPTION
remove `--dateFormat` and `--localTime` options
`--translateTime` (`-t`) accept an optional format string
  - `-t` convert into UTC ISO format, default: `yyyy-mm-dd HH:MM:ss.l o`
  - `-t 'HH:MM:ss.l'` convert into UTC in 'HH:MM:ss.l' format
  - `-t 'SYS:standard'` convert into system's timezone, default: `yyyy-mm-dd HH:MM:ss.l o`
  - `-t 'SYS:HH:MM:ss'` convert into system's timezone in 'HH:MM:ss' format

#### checklist
- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
