### PR TITLE
Removes the `.asMetaWrapper` method since it is in core

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -49,7 +49,7 @@ error like objects. Default: `err,error`.
 Default: `msg`.
 + `--translateTime` (`-t`): Translate the epoch time value into a human readable
 date and time string in `UTC`. The default pattern is `'yyyy-mm-dd HH:MM:ss.l o'`.
-If you want to translate to the local system's timezone, then you must prefix the format 
+If you want to translate to the local system's timezone, then you must prefix the format
 string with `SYS:`, e.g. `'SYS:yyyy-mm-dd HH:MM:ss'`. See [`dateformat` documentation](https://www.npmjs.com/package/dateformat#mask-options)
 for more available pattern letters.
 + `--search` (`-s`): Specifiy a search pattern according to
@@ -75,32 +75,10 @@ in [CLI Arguments](#cliargs):
 }
 ```
 
-See the [next subsection](#usemetadata) for information on how to use this
-directly with `pino`.
+See the [Pino's prettifier documentation](#usemetadata) for information on how
+to use this directly with `pino`.
 
-<a id="usemetadata"></a>
-### pretty.asMetaWrapper(writable)
-
-```js
-const factory = require('pino-pretty')
-const pino = require('pino')
-
-// writable is any Writable stream
-const writable = process.stdout
-const dest = factory({ colorize: true }).asMetaWrapper(writable)
-
-const logger = pino({}, dest)
-```
-
-The function returned by the factory has a `.asMetaWrapper(dest)` function attached
-which will return an object that can be supplied directly to Pino as a stream
-that is compatible with Pino's [metadata stream API][mdstream].
-This allows `pino-pretty` to skip the expensive task of parsing JSON log lines
-and instead work directly with Pino's log object.
-
-The default stream is `process.stdout`.
-
-[mdstream]: https://github.com/pinojs/pino/blob/fc4c83b/docs/API.md#metadata
+[#usemetadata]: https://getpino.io/#/docs/pretty
 
 <a id="license"><a>
 ## License

--- a/index.js
+++ b/index.js
@@ -86,8 +86,6 @@ module.exports = function prettyFactory (options) {
     color.message = ctx.cyan
   }
 
-  pretty.asMetaWrapper = asMetaWrapper
-
   const search = opts.search
 
   return pretty
@@ -251,44 +249,6 @@ module.exports = function prettyFactory (options) {
       }
 
       return result
-    }
-  }
-}
-
-function asMetaWrapper (dest) {
-  const parsed = Symbol('parsedChindings')
-
-  if (!dest) {
-    dest = process.stdout
-  } else if (!dest.write) {
-    throw new Error('the destination must be writable')
-  }
-
-  const pretty = this
-
-  return {
-    [Symbol.for('needsMetadata')]: true,
-    lastLevel: 0,
-    lastMsg: null,
-    lastObj: null,
-    lastLogger: null,
-    write (chunk) {
-      if (chunk === undefined) return
-      var chindings = this.lastLogger[parsed]
-
-      if (!chindings) {
-        chindings = JSON.parse('{"v":1' + this.lastLogger.chindings + '}')
-        this.lastLogger[parsed] = chindings
-      }
-
-      const obj = Object.assign({
-        level: this.lastLevel,
-        msg: this.lastMsg,
-        time: this.lastTime
-      }, chindings, this.lastObj)
-
-      const formatted = pretty(obj)
-      dest.write(formatted)
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "through2": "^2.0.3"
   },
   "devDependencies": {
-    "pino": "^5.0.0-rc.1",
+    "pino": "^5.0.0-rc.2",
     "pre-commit": "^1.2.2",
     "snazzy": "^7.1.1",
     "standard": "^11.0.1",

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -371,8 +371,10 @@ test('basic prettifier tests', (t) => {
         cb()
       }
     })
-    const prettyStream = prettyFactory().asMetaWrapper(dest)
-    const log = pino({}, prettyStream)
+    const log = pino({
+      prettifier: prettyFactory,
+      prettyPrint: true
+    }, dest)
     log.info('foo')
   })
 
@@ -389,9 +391,12 @@ test('basic prettifier tests', (t) => {
         cb()
       }
     })
-
-    const prettyStream = prettyFactory({ levelFirst: true }).asMetaWrapper(dest)
-    const log = pino({}, prettyStream)
+    const log = pino({
+      prettifier: prettyFactory,
+      prettyPrint: {
+        levelFirst: true
+      }
+    }, dest)
     log.info('foo')
   })
 


### PR DESCRIPTION
As titled. Solves #9.