### PR TITLE
Fix printing stack traces on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -235,13 +235,13 @@ module.exports = function prettyFactory (options) {
             const line = arrayOfLines[j]
 
             if (/^\s*"stack"/.test(line)) {
-              const matches = /^(\s*"stack":)\s*"(.*)",?$/.exec(line)
+              const matches = /^(\s*"stack":)\s*(".*"),?$/.exec(line)
 
               if (matches && matches.length === 3) {
                 const indentSize = /^\s*/.exec(line)[0].length + 4
-                const indentation = Array(indentSize + 1).join(' ')
+                const indentation = ' '.repeat(indentSize)
 
-                result += matches[1] + '\n' + indentation + matches[2].replace(/\\n/g, '\n' + indentation)
+                result += matches[1] + '\n' + indentation + JSON.parse(matches[2]).replace(/\n/g, '\n' + indentation)
               }
             } else {
               result += line


### PR DESCRIPTION
Since Windows paths use `\` as a path separator, files and directories that start with an `n` cause a newline to be printed instead of `...\n...`.

Example:

<details>
<summary>Code (in file <code>C:\node-pino-test\pino-test.js</code>)</summary>

```js
const pino = require('pino')({
  prettyPrint: true,
})

pino.info({err: new Error('hello')})
```
</details><br>

```
[1539308550926] INFO (19440 on my-pc):
    err: {
      "type": "Error",
      "message": "hello",
      "stack":
          Error: hello
              at Object.<anonymous> (C:\
          ode-pino-test\\pino-test.js:8:17)
              at Module._compile (internal/modules/cjs/loader.js:689:30)
              at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
              at Module.load (internal/modules/cjs/loader.js:599:32)
              at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
              at Function.Module._load (internal/modules/cjs/loader.js:530:3)
              at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
              at startup (internal/bootstrap/node.js:279:19)
              at bootstrapNodeJSCore (internal/bootstrap/node.js:752:3)
    }
```

With this fix, the following is printed instead:

```
[1539309961942] INFO (25428 on my-pc):
    err: {
      "type": "Error",
      "message": "hello",
      "stack":
          Error: hello
              at Object.<anonymous> (C:\node-pino-test\pino-test.js:8:17)
              at Module._compile (internal/modules/cjs/loader.js:689:30)
              at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
              at Module.load (internal/modules/cjs/loader.js:599:32)
              at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
              at Function.Module._load (internal/modules/cjs/loader.js:530:3)
              at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
              at startup (internal/bootstrap/node.js:279:19)
              at bootstrapNodeJSCore (internal/bootstrap/node.js:752:3)
    }
```