### PR TITLE
skip undefined values, fixes #45

### DIFF
--- a/index.js
+++ b/index.js
@@ -221,9 +221,11 @@ module.exports = function prettyFactory (options) {
 
       for (var i = 0; i < keys.length; i += 1) {
         if (errorLikeObjectKeys.indexOf(keys[i]) !== -1 && value[keys[i]] !== undefined) {
+          const lines = JSON.stringify(value[keys[i]], null, 2)
+          if (lines === undefined) continue
           const arrayOfLines = (
             IDENT + keys[i] + ': ' +
-            joinLinesWithIndentation(JSON.stringify(value[keys[i]], null, 2)) +
+            joinLinesWithIndentation(lines) +
             EOL
           ).split('\n')
 
@@ -249,7 +251,10 @@ module.exports = function prettyFactory (options) {
           }
         } else if (filteredKeys.indexOf(keys[i]) < 0) {
           if (value[keys[i]] !== undefined) {
-            result += IDENT + keys[i] + ': ' + joinLinesWithIndentation(JSON.stringify(value[keys[i]], null, 2)) + EOL
+            const lines = JSON.stringify(value[keys[i]], null, 2)
+            if (lines !== undefined) {
+              result += IDENT + keys[i] + ': ' + joinLinesWithIndentation(lines) + EOL
+            }
           }
         }
       }

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -485,5 +485,30 @@ test('basic prettifier tests', (t) => {
     log.info({ msg: { b: { c: 'd' } } })
   })
 
+  t.test('prettifies object with some undefined values', (t) => {
+    t.plan(1)
+    const dest = new Writable({
+      write (chunk, _, cb) {
+        t.is(
+          chunk + '',
+          `[${epoch}] INFO (${pid} on ${hostname}): \n    a: {\n      "b": "c"\n    }\n    n: null\n`
+        )
+        cb()
+      }
+    })
+    const log = pino({
+      prettifier: prettyFactory,
+      prettyPrint: true
+    }, dest)
+    log.info({
+      a: { b: 'c' },
+      s: Symbol.for('s'),
+      f: f => f,
+      c: class C {},
+      n: null,
+      err: { toJSON () {} }
+    })
+  })
+
   t.end()
 })


### PR DESCRIPTION
check if value is undefined after calling JSON.stringify(value).
If the value is undefined the output is skipped preserving indentation.

Added a test verifying both error and non error like keys that resolve to undefined.

Undefined values can occur in a number of scenarios, some being -

* The value is a function `JSON.stringify(f => f)` => undefined
* The value is a class `JSON.stringify(class F {})` => undefined
* The value is a symbol `JSON.stringify(Symbol.for('x'))` => undefined
* The value has a serialize function that returns undefined `JSON.stringify({ toJSON() {} })` => undefined