### PR TITLE
Omit empty brackets if log.time is falsey

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ module.exports = function prettyFactory (options) {
       log.time = formatTime(log.time, opts.translateTime)
     }
 
-    var line = `[${log.time}]`
+    var line = log.time ? `[${log.time}]` : ''
 
     const coloredLevel = levels.hasOwnProperty(log.level)
       ? color[log.level](levels[log.level])
@@ -128,7 +128,10 @@ module.exports = function prettyFactory (options) {
     if (opts.levelFirst) {
       line = `${coloredLevel} ${line}`
     } else {
-      line = `${line} ${coloredLevel}`
+      // If the line is not empty (timestamps are enabled) output it
+      // with a space after it - otherwise output the empty string
+      const lineOrEmpty = line && line + ' '
+      line = `${lineOrEmpty}${coloredLevel}`
     }
 
     if (log.name || log.pid || log.hostname) {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -276,7 +276,7 @@ test('basic prettifier tests', (t) => {
     const log = pino({ timestamp: null }, new Writable({
       write (chunk, enc, cb) {
         const formatted = pretty(chunk.toString())
-        t.is(formatted, `[undefined] INFO  (${pid} on ${hostname}): hello world\n`)
+        t.is(formatted, `INFO  (${pid} on ${hostname}): hello world\n`)
         cb()
       }
     }))


### PR DESCRIPTION
This PR checks for a `time` on the log object and either operates as normal or totally ignores that section of the log if `time` falsey.

One thing to note - getting the spaces between the timestamp and the level strings was tricky, that's why I needed to do this:

```js
const lineOrEmpty = line && line + ' '
line = `${lineOrEmpty}${coloredLevel}`
```

Otherwise it would output this (notice the leading space):

```
# Bad
 LEVEL ...
# Good
LEVEL ...
```

Happy to make any necessary changes, just let me know 😊 

Closes #48 