### PR TITLE
Add safe stringify

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const dateformat = require('dateformat')
 // remove jsonParser once Node 6 is not supported anymore
 const jsonParser = require('fast-json-parse')
 const jmespath = require('jmespath')
+const stringifySafe = require('fast-safe-stringify')
 
 const CONSTANTS = require('./lib/constants')
 
@@ -224,7 +225,7 @@ module.exports = function prettyFactory (options) {
 
       for (var i = 0; i < keys.length; i += 1) {
         if (errorLikeObjectKeys.indexOf(keys[i]) !== -1 && value[keys[i]] !== undefined) {
-          const lines = JSON.stringify(value[keys[i]], null, 2)
+          const lines = stringifySafe(value[keys[i]], null, 2)
           if (lines === undefined) continue
           const arrayOfLines = (
             IDENT + keys[i] + ': ' +
@@ -254,7 +255,7 @@ module.exports = function prettyFactory (options) {
           }
         } else if (filteredKeys.indexOf(keys[i]) < 0) {
           if (value[keys[i]] !== undefined) {
-            const lines = JSON.stringify(value[keys[i]], null, 2)
+            const lines = stringifySafe(value[keys[i]], null, 2)
             if (lines !== undefined) {
               result += IDENT + keys[i] + ': ' + joinLinesWithIndentation(lines) + EOL
             }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "chalk": "^2.3.2",
     "dateformat": "^3.0.3",
     "fast-json-parse": "^1.0.3",
+    "fast-safe-stringify": "^2.0.6",
     "jmespath": "^0.15.0",
     "pump": "^3.0.0",
     "readable-stream": "^3.0.6",


### PR DESCRIPTION
This PR uses the same [fast-safe-stringify](https://github.com/davidmarkclements/fast-safe-stringify) library used in [pino](https://github.com/pinojs/pino) to avoid errors about circular references when logging.

Example:

```js
'use strict';

const pino = require('pino');

const logger = pino({
  prettyPrint: {
    levelFirst: true
  },
  prettifier: require('pino-pretty')
});

const logInfo = { a: 1, b: 2 };
// Circular reference
logInfo.c = logInfo;

// This could throw an error due to the circular reference
logger.info(logInfo, 'an info log');
```

This PR closes #51.