### PR TITLE
Add ability to load run configuration from json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ profile-*
 
 # VS Code
 .vscode/
+
+# Run Configuration
+.pino-prettyrc.json
+.pino-prettyrc.test.json

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ profile-*
 # Run Configuration
 .pino-prettyrc.json
 .pino-prettyrc.test.json
+test/.tmp*

--- a/Readme.md
+++ b/Readme.md
@@ -68,7 +68,7 @@ letters see the [`dateformat` documentation](https://www.npmjs.com/package/datef
     system timezone.
 + `--search` (`-s`): Specifiy a search pattern according to
   [jmespath](http://jmespath.org/).
-  `--option-file` (`-o`): Specify a path to a json file containing the pino-pretty options.  pino-pretty will attempt to read from  `process.cwd() + '/.pino-prettyrc.json'` if not specified
++ `--options-file` (`-o`): Specify a path to a json file containing the pino-pretty options.  pino-pretty will attempt to read from a `.pino-prettyrc.json` in your current directory (`process.cwd`) if not specified
 
 <a id="integration"></a>
 ## Programmatic Integration 

--- a/Readme.md
+++ b/Readme.md
@@ -68,6 +68,7 @@ letters see the [`dateformat` documentation](https://www.npmjs.com/package/datef
     system timezone.
 + `--search` (`-s`): Specifiy a search pattern according to
   [jmespath](http://jmespath.org/).
+  `--option-file` (`-o`): Specify a path to a json file containing the pino-pretty options.  pino-pretty will attempt to read from  `process.cwd() + '/.pino-prettyrc.json'` if not specified
 
 <a id="integration"></a>
 ## Programmatic Integration 

--- a/bin.js
+++ b/bin.js
@@ -17,6 +17,7 @@ args
   .option(['m', 'messageKey'], 'Highlight the message under the specified key', CONSTANTS.MESSAGE_KEY)
   .option(['t', 'translateTime'], 'Display epoch timestamps as UTC ISO format or according to an optional format string (default ISO 8601)')
   .option(['s', 'search'], 'specifiy a search pattern according to jmespath')
+  .option(['o', 'option-file'], 'specify a path to a json file containing the pino-pretty options')
 
 args
   .example('cat log | pino-pretty', 'To prettify logs, simply pipe a log file through')
@@ -25,6 +26,7 @@ args
   .example('cat log | pino-pretty -t "SYS:yyyy-mm-dd HH:MM:ss"', 'To convert Epoch timestamps to local timezone format use the -t option with "SYS:" prefixed format string')
   .example('cat log | pino-pretty -l', 'To flip level and time/date in standard output use the -l option')
   .example('cat log | pino-pretty -s "msg == \'hello world\'"', 'Only prints messages with msg equals to \'hello world\'')
+  .example('cat log | pino-pretty -o /path/to/options.json', 'Loads options from a json file')
 
 const opts = args.parse(process.argv)
 const pretty = prettyFactory(opts)

--- a/bin.js
+++ b/bin.js
@@ -17,7 +17,7 @@ args
   .option(['m', 'messageKey'], 'Highlight the message under the specified key', CONSTANTS.MESSAGE_KEY)
   .option(['t', 'translateTime'], 'Display epoch timestamps as UTC ISO format or according to an optional format string (default ISO 8601)')
   .option(['s', 'search'], 'specifiy a search pattern according to jmespath')
-  .option(['o', 'option-file'], 'specify a path to a json file containing the pino-pretty options')
+  .option(['o', 'options-file'], 'specify a path to a json file containing the pino-pretty options')
 
 args
   .example('cat log | pino-pretty', 'To prettify logs, simply pipe a log file through')

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const dateformat = require('dateformat')
 const jsonParser = require('fast-json-parse')
 const jmespath = require('jmespath')
 const stringifySafe = require('fast-safe-stringify')
+const path = require('path')
 
 const CONSTANTS = require('./lib/constants')
 
@@ -28,7 +29,8 @@ const defaultOptions = {
   messageKey: CONSTANTS.MESSAGE_KEY,
   translateTime: false,
   useMetadata: false,
-  outputStream: process.stdout
+  outputStream: process.stdout,
+  optionFile: path.join(process.cwd(), '.pino-prettyrc.json')
 }
 
 function isObject (input) {
@@ -59,6 +61,15 @@ function nocolor (input) {
 
 module.exports = function prettyFactory (options) {
   const opts = Object.assign({}, defaultOptions, options)
+  try {
+    const runConfiguration = require(opts.optionFile)
+    Object.assign(opts, runConfiguration)
+  } catch (error) {
+    // Only throw an error if the options file path is not the default
+    if (defaultOptions.optionFile !== opts.optionFile) {
+      throw new Error('Failed to load runtime configuration file [' + opts.optionFile + ']')
+    }
+  }
   const EOL = opts.crlf ? '\r\n' : '\n'
   const IDENT = '    '
   const messageKey = opts.messageKey

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ const defaultOptions = {
   translateTime: false,
   useMetadata: false,
   outputStream: process.stdout,
-  optionFile: path.join(process.cwd(), '.pino-prettyrc.json')
+  optionsFile: path.join(process.cwd(), '.pino-prettyrc.json')
 }
 
 function isObject (input) {
@@ -62,12 +62,12 @@ function nocolor (input) {
 module.exports = function prettyFactory (options) {
   const opts = Object.assign({}, defaultOptions, options)
   try {
-    const runConfiguration = require(opts.optionFile)
+    const runConfiguration = require(opts.optionsFile)
     Object.assign(opts, runConfiguration)
   } catch (error) {
     // Only throw an error if the options file path is not the default
-    if (defaultOptions.optionFile !== opts.optionFile) {
-      throw new Error('Failed to load runtime configuration file [' + opts.optionFile + ']')
+    if (defaultOptions.optionsFile !== opts.optionsFile) {
+      throw new Error('Failed to load runtime configuration file [' + opts.optionsFile + ']')
     }
   }
   const EOL = opts.crlf ? '\r\n' : '\n'

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "jmespath": "^0.15.0",
     "pump": "^3.0.0",
     "readable-stream": "^3.0.6",
+    "rimraf": "^2.6.3",
     "split2": "^3.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "scripts": {
     "lint": "standard | snazzy",
     "lint-ci": "standard",
+    "pretest": "echo {} > ./.pino-prettyrc.json",
     "test": "tap --no-cov 'test/**/*.test.js'",
+    "pretest-ci": "echo {} > ./.pino-prettyrc.json",
     "test-ci": "tap --cov 'test/**/*.test.js'"
   },
   "repository": {

--- a/test/cli-rc.test.js
+++ b/test/cli-rc.test.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const path = require('path')
+const spawn = require('child_process').spawn
+const test = require('tap').test
+
+const bin = require.resolve(path.join(__dirname, '..', 'bin.js'))
+const logLine = '{"level":30,"time":1522431328992,"msg":"hello world","pid":42,"hostname":"foo","v":1}\n'
+const rcFile = path.join(process.cwd(), '.pino-prettyrc.json')
+
+test('cli', (t) => {
+  t.afterEach((done) => {
+    // Update .pino-prettyrc.json with empty options
+    require('fs').writeFileSync(rcFile, JSON.stringify({}, null, 4))
+    done()
+  })
+
+  t.test('loads and applies .pino-prettyrc.json', (t) => {
+    t.plan(1)
+    // Set translateTime: true on run configuration
+    require('fs').writeFileSync(rcFile, JSON.stringify({ translateTime: true }, null, 4))
+    // Validate that the time has been translated
+    const child = spawn(process.argv0, [bin])
+    child.on('error', t.threw)
+    child.stdout.on('data', (data) => {
+      t.is(data.toString(), `[2018-03-30 17:35:28.992 +0000] INFO  (42 on foo): hello world\n`)
+    })
+    child.stdin.write(logLine)
+    t.tearDown(() => child.kill())
+  })
+
+  t.test('loads and applies .pino-prettyrc.test.json', (t) => {
+    t.plan(1)
+    // Set translateTime: true on run configuration
+    let testRcFile = path.join(process.cwd(), '.pino-prettyrc.test.json')
+    require('fs').writeFileSync(testRcFile, JSON.stringify({ translateTime: true }, null, 4))
+    // Validate that the time has been translated
+    const child = spawn(process.argv0, [bin, '-o', testRcFile])
+    child.on('error', t.threw)
+    child.stdout.on('data', (data) => {
+      t.is(data.toString(), `[2018-03-30 17:35:28.992 +0000] INFO  (42 on foo): hello world\n`)
+    })
+    child.stdin.write(logLine)
+    t.tearDown(() => child.kill())
+  })
+
+  t.end()
+})

--- a/test/cli-rc.test.js
+++ b/test/cli-rc.test.js
@@ -3,21 +3,32 @@
 const path = require('path')
 const spawn = require('child_process').spawn
 const test = require('tap').test
+const fs = require('fs')
+const rimraf = require('rimraf')
 
 const bin = require.resolve(path.join(__dirname, '..', 'bin.js'))
 const logLine = '{"level":30,"time":1522431328992,"msg":"hello world","pid":42,"hostname":"foo","v":1}\n'
-const rcFile = path.join(process.cwd(), '.pino-prettyrc.json')
 
 test('cli', (t) => {
-  t.afterEach((done) => {
-    // Update .pino-prettyrc.json with empty options
-    require('fs').writeFileSync(rcFile, JSON.stringify({}, null, 4))
+  let tmpDir
+  t.beforeEach((done) => {
+    tmpDir = path.join(__dirname, '.tmp' + Math.random())
+    fs.mkdirSync(tmpDir)
+    process.chdir(tmpDir)
     done()
+  })
+
+  t.afterEach((done) => {
+    rimraf(tmpDir, () => {
+      process.chdir(path.join(__dirname, '..'))
+      done()
+    })
   })
 
   t.test('loads and applies .pino-prettyrc.json', (t) => {
     t.plan(1)
     // Set translateTime: true on run configuration
+    let rcFile = path.join(process.cwd(), '.pino-prettyrc.json')
     require('fs').writeFileSync(rcFile, JSON.stringify({ translateTime: true }, null, 4))
     // Validate that the time has been translated
     const child = spawn(process.argv0, [bin])


### PR DESCRIPTION
This will allow specifying run configurations loaded from `./.pino-prettyrc.json` by default or specifying a path via a new --options-file cli param.