### PR TITLE
New option and command line argument to ignore some keys

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -68,6 +68,7 @@ letters see the [`dateformat` documentation](https://www.npmjs.com/package/datef
     system timezone.
 + `--search` (`-s`): Specifiy a search pattern according to
   [jmespath](http://jmespath.org/).
++ `--ignore` (`-i`): Ignore one or several keys: (`-i time,hostname`)
 
 <a id="integration"></a>
 ## Programmatic Integration 

--- a/Readme.md
+++ b/Readme.md
@@ -66,7 +66,7 @@ letters see the [`dateformat` documentation](https://www.npmjs.com/package/datef
   - Require a `SYS:` prefix to translate time to the local system's timezone. A
     shortcut `SYS:standard` to translate time to `yyyy-mm-dd HH:MM:ss.l o` in
     system timezone.
-+ `--search` (`-s`): Specifiy a search pattern according to
++ `--search` (`-s`): Specify a search pattern according to
   [jmespath](http://jmespath.org/).
 + `--ignore` (`-i`): Ignore one or several keys: (`-i time,hostname`)
 
@@ -121,7 +121,8 @@ with keys corresponding to the options described in [CLI Arguments](#cliargs):
   levelFirst: false, // --levelFirst
   messageKey: 'msg', // --messageKey
   translateTime: false, // --translateTime
-  search: 'foo == `bar`' // --search
+  search: 'foo == `bar`', // --search
+  ignore: 'pid,hostname' // --ignore
 }
 ```
 

--- a/bin.js
+++ b/bin.js
@@ -16,7 +16,7 @@ args
   .option(['k', 'errorLikeObjectKeys'], 'Define which keys contain error objects (`-k err,error`)', 'err,error')
   .option(['m', 'messageKey'], 'Highlight the message under the specified key', CONSTANTS.MESSAGE_KEY)
   .option(['t', 'translateTime'], 'Display epoch timestamps as UTC ISO format or according to an optional format string (default ISO 8601)')
-  .option(['s', 'search'], 'Specifiy a search pattern according to jmespath')
+  .option(['s', 'search'], 'Specify a search pattern according to jmespath')
   .option(['i', 'ignore'], 'Ignore one or several keys: (`-i time,hostname`)')
 
 args

--- a/bin.js
+++ b/bin.js
@@ -16,7 +16,8 @@ args
   .option(['k', 'errorLikeObjectKeys'], 'Define which keys contain error objects (`-k err,error`)', 'err,error')
   .option(['m', 'messageKey'], 'Highlight the message under the specified key', CONSTANTS.MESSAGE_KEY)
   .option(['t', 'translateTime'], 'Display epoch timestamps as UTC ISO format or according to an optional format string (default ISO 8601)')
-  .option(['s', 'search'], 'specifiy a search pattern according to jmespath')
+  .option(['s', 'search'], 'Specifiy a search pattern according to jmespath')
+  .option(['i', 'ignore'], 'Ignore one or several keys: (`-i time,hostname`)')
 
 args
   .example('cat log | pino-pretty', 'To prettify logs, simply pipe a log file through')
@@ -25,6 +26,7 @@ args
   .example('cat log | pino-pretty -t "SYS:yyyy-mm-dd HH:MM:ss"', 'To convert Epoch timestamps to local timezone format use the -t option with "SYS:" prefixed format string')
   .example('cat log | pino-pretty -l', 'To flip level and time/date in standard output use the -l option')
   .example('cat log | pino-pretty -s "msg == \'hello world\'"', 'Only prints messages with msg equals to \'hello world\'')
+  .example('cat log | pino-pretty -i pid,hostname', 'Prettify logs but don\'t print pid and hostname')
 
 const opts = args.parse(process.argv)
 const pretty = prettyFactory(opts)

--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ module.exports = function prettyFactory (options) {
   const messageKey = opts.messageKey
   const errorLikeObjectKeys = opts.errorLikeObjectKeys
   const errorProps = opts.errorProps.split(',')
+  const ignoreKeys = opts.ignore ? new Set(opts.ignore.split(',')) : undefined
 
   const color = {
     default: nocolor,
@@ -106,6 +107,15 @@ module.exports = function prettyFactory (options) {
 
     if (search && !jmespath.search(log, search)) {
       return
+    }
+
+    if (ignoreKeys) {
+      log = Object.keys(log)
+        .filter(key => !ignoreKeys.has(key))
+        .reduce((res, key) => {
+          res[key] = log[key]
+          return res
+        }, {})
     }
 
     const standardKeys = [

--- a/index.js
+++ b/index.js
@@ -159,7 +159,10 @@ module.exports = function prettyFactory (options) {
       }
 
       if (log.hostname) {
-        line += ' on ' + log.hostname
+        if (line.slice(-1) !== '(') {
+          line += ' '
+        }
+        line += 'on ' + log.hostname
       }
 
       line += ')'

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -539,5 +539,19 @@ test('basic prettifier tests', (t) => {
     })
   })
 
+  t.test('ignores multiple keys', (t) => {
+    t.plan(1)
+    const pretty = prettyFactory({ ignore: 'pid,hostname' })
+    const arst = pretty(`{"msg":"hello world", "pid":"${pid}", "hostname":"${hostname}", "time":${epoch}, "level":30, "v":1}`)
+    t.is(arst, `[${epoch}] INFO : hello world\n`)
+  })
+
+  t.test('ignores a single key', (t) => {
+    t.plan(1)
+    const pretty = prettyFactory({ ignore: 'pid' })
+    const arst = pretty(`{"msg":"hello world", "pid":"${pid}", "hostname":"${hostname}", "time":${epoch}, "level":30, "v":1}`)
+    t.is(arst, `[${epoch}] INFO  (on imoo.local): hello world\n`)
+  })
+
   t.end()
 })

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -550,7 +550,7 @@ test('basic prettifier tests', (t) => {
     t.plan(1)
     const pretty = prettyFactory({ ignore: 'pid' })
     const arst = pretty(`{"msg":"hello world", "pid":"${pid}", "hostname":"${hostname}", "time":${epoch}, "level":30, "v":1}`)
-    t.is(arst, `[${epoch}] INFO  (on imoo.local): hello world\n`)
+    t.is(arst, `[${epoch}] INFO  (on ${hostname}): hello world\n`)
   })
 
   t.end()

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -53,5 +53,16 @@ test('cli', (t) => {
     t.tearDown(() => child.kill())
   })
 
+  t.test('does ignore multiple keys', (t) => {
+    t.plan(1)
+    const child = spawn(process.argv0, [bin, '-i', 'pid,hostname'])
+    child.on('error', t.threw)
+    child.stdout.on('data', (data) => {
+      t.is(data.toString(), `[1522431328992] INFO : hello world\n`)
+    })
+    child.stdin.write(logLine)
+    t.tearDown(() => child.kill())
+  })
+
   t.end()
 })


### PR DESCRIPTION
I love `pino` and `pino-pretty` but I really don't care about the pid and hostname on my dev machine. I added a new option `--ignore` to customize the output.


Example use:
```sh
$ echo '{"level":30,"time":1522431328992,"msg":"hello world","pid":42,"hostname":"foo","v":1, "name":"pou"}' | node bin.js -ti pid,hostname,name
[2018-03-30 17:35:28.992 +0000] INFO : hello world
```

Note: I added a few tests