### PR TITLE
[dependencies] bourne updated

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const {
   prettifyTime
 } = require('./lib/utils')
 
-const bourne = require('bourne')
+const bourne = require('@hapi/bourne')
 const jsonParser = input => {
   try {
     return { value: bourne.parse(input, { protoAction: 'remove' }) }

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "test"
   ],
   "dependencies": {
+    "@hapi/bourne": "^1.3.2",
     "args": "^5.0.1",
-    "bourne": "^1.1.2",
     "chalk": "^2.4.2",
     "dateformat": "^3.0.3",
     "fast-safe-stringify": "^2.0.6",

--- a/test/lib/utils.internals.test.js
+++ b/test/lib/utils.internals.test.js
@@ -46,7 +46,7 @@ tap.test('#formatTime', t => {
 
   t.test('translates epoch milliseconds to SYS:<FORMAT>', async t => {
     const formattedTime = internals.formatTime(epochMS, 'SYS:d mmm yyyy H:MM')
-    t.match(formattedTime, /\d{1} \w{3} \d{4} \d{2}:\d{2}/)
+    t.match(formattedTime, /\d{1} \w{3} \d{4} \d{1,2}:\d{2}/)
   })
 
   t.test('passes through date string if `translateTime` is `false`', async t => {
@@ -76,7 +76,7 @@ tap.test('#formatTime', t => {
 
   t.test('translates date string to SYS:<FORMAT>', async t => {
     const formattedTime = internals.formatTime(dateStr, 'SYS:d mmm yyyy H:MM')
-    t.match(formattedTime, /\d{1} \w{3} \d{4} \d{2}:\d{2}/)
+    t.match(formattedTime, /\d{1} \w{3} \d{4} \d{1,2}:\d{2}/)
   })
 
   t.end()


### PR DESCRIPTION
See #63 for details. And I'm updated tests for GMT+7 or upper timezones. In these timezones test string `2019-04-06T13:30:00.000-04:00` is `7 Apr 2019 00:30`.