### PR TITLE
add check for numbers

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ module.exports = function prettyFactory (options) {
     }
 
     // Short-circuit for spec allowed primitive values.
-    if ([null, true, false].includes(log)) {
+    if ([null, true, false].includes(log) || Number.isFinite(log)) {
       return `${log}\n`
     }
 

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -349,6 +349,20 @@ test('basic prettifier tests', (t) => {
     t.end()
   })
 
+  t.test('handles numbers', (t) => {
+    const pretty = prettyFactory()
+    let formatted = pretty(2)
+    t.is(formatted, '2\n')
+
+    formatted = pretty(-2)
+    t.is(formatted, '-2\n')
+
+    formatted = pretty(0.2)
+    t.is(formatted, '0.2\n')
+
+    t.end()
+  })
+
   t.test('handles `undefined` input', (t) => {
     t.plan(1)
     const pretty = prettyFactory()

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -360,6 +360,12 @@ test('basic prettifier tests', (t) => {
     formatted = pretty(0.2)
     t.is(formatted, '0.2\n')
 
+    formatted = pretty(Infinity)
+    t.is(formatted, 'Infinity\n')
+
+    formatted = pretty(NaN)
+    t.is(formatted, 'NaN\n')
+
     t.end()
   })
 


### PR DESCRIPTION
Checks for number input and prevents crashing as reported in issue #69

Example: `node -e 'console.log(2)' | node ./bin.js`