### PR TITLE
Handle timestamp 0 in prettifyTime

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -326,9 +326,18 @@ function prettifyObject ({
  * string.
  */
 function prettifyTime ({ log, timestampKey = TIMESTAMP_KEY, translateFormat = undefined }) {
-  if (timestampKey in log === false && 'timestamp' in log === false) return undefined
-  if (translateFormat) {
-    return '[' + formatTime(log[timestampKey] || log.timestamp, translateFormat) + ']'
+  let time = null
+
+  if (timestampKey in log) {
+    time = log[timestampKey]
+  } else if ('timestamp' in log) {
+    time = log.timestamp
   }
-  return `[${log[timestampKey] || log.timestamp}]`
+
+  if (time === null) return undefined
+  if (translateFormat) {
+    return '[' + formatTime(time, translateFormat) + ']'
+  }
+
+  return `[${time}]`
 }

--- a/test/lib/utils.public.test.js
+++ b/test/lib/utils.public.test.js
@@ -252,5 +252,15 @@ tap.test('prettifyTime', t => {
     t.is(str, '[2019-04-07T09:15:00.000-04:00]')
   })
 
+  t.test('handles the 0 timestamp', async t => {
+    let log = { time: 0 }
+    let str = prettifyTime({ log })
+    t.is(str, '[0]')
+
+    log = { timestamp: 0 }
+    str = prettifyTime({ log })
+    t.is(str, '[0]')
+  })
+
   t.end()
 })


### PR DESCRIPTION
When trying to format a log object like the following:

```json
{
  "level": 30,
  "time": 0,
  "name": "foobar",
  "msg": "I like cake",
  "v": 1
}
```

pino-pretty previously tried to format the timestamp `undefined` instead of
taking the `0` time. This commit looks not at the truthiness of the value, but
its existence.