### PR TITLE
Add `module` as a prettified property

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const {
   isObject,
   prettifyErrorLog,
   prettifyLevel,
+  prettifyModule,
   prettifyMessage,
   prettifyMetadata,
   prettifyObject,
@@ -83,6 +84,7 @@ module.exports = function prettyFactory (options) {
     }
 
     const prettifiedLevel = prettifyLevel({ log, colorizer })
+    const prettifiedModule = prettifyModule({ log, colorizer })
     const prettifiedMessage = prettifyMessage({ log, messageKey, colorizer })
     const prettifiedMetadata = prettifyMetadata({ log })
     const prettifiedTime = prettifyTime({ log, translateFormat: opts.translateTime, timestampKey })
@@ -112,6 +114,10 @@ module.exports = function prettyFactory (options) {
 
     if (line.endsWith(':') === false && line !== '') {
       line += ':'
+    }
+    
+    if (prettifiedModule) {
+       line = `${line} [${prettifiedModule}]`
     }
 
     if (prettifiedMessage) {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -36,6 +36,7 @@ module.exports = {
     'level',
     'time',
     'timestamp',
-    'v'
+    'v',
+    'module'
   ]
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -198,7 +198,7 @@ function prettifyLevel ({ log, colorizer = defaultColorizer }) {
  */
 function prettifyModule ({ log, colorizer = defaultColorizer }){
   if ('module' in log === false) return undefined
-  return colorizer(log.module)
+  return colorizer.message(log.module)
 }
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,6 +15,7 @@ module.exports = {
   isObject,
   prettifyErrorLog,
   prettifyLevel,
+  prettifyModule,
   prettifyMessage,
   prettifyMetadata,
   prettifyObject,
@@ -177,6 +178,27 @@ function prettifyErrorLog ({
 function prettifyLevel ({ log, colorizer = defaultColorizer }) {
   if ('level' in log === false) return undefined
   return colorizer(log.level)
+}
+
+/**
+ * Checks if the passed in log has a `module` value and returns a prettified
+ * string for that module name if so.
+ *
+ * The module value is the encouraged way for pino child loggers to identify
+ * themselves.
+ *
+ * @param {object} input
+ * @param {object} input.log The log object which should have a `module` property.
+ * @param {function} [input.colorizer] A colorizer function that accepts a value
+ * and returns a colorized string. Default: a no-op colorizer.
+ *
+ * @returns {undefined|string} If `log` does not have a `module` property then
+ * `undefined` will be returned. Otherwise, a string from the specified
+ * `colorizer` is returned.
+ */
+function prettifyModule ({ log, colorizer = defaultColorizer }){
+  if ('module' in log === false) return undefined
+  return colorizer(log.module)
 }
 
 /**


### PR DESCRIPTION
In the Pino documentation, it is mentioned that [child loggers](https://github.com/pinojs/pino/blob/master/docs/child-loggers.md) can add properties to log output.

We have child loggers for different modules, as is imagined in the documentation and we use the `module` property to identify it.

This PR changes the log output such that it will include `[module] <message>`.