### PR TITLE
Pass through non-object valid JSON, fixes #72

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,11 +55,11 @@ module.exports = function prettyFactory (options) {
     let log
     if (!isObject(inputData)) {
       const parsed = jsonParser(inputData)
-      log = parsed.value
-      if (parsed.err) {
+      if (parsed.err || !isObject(parsed.value)) {
         // pass through
         return inputData + EOL
       }
+      log = parsed.value
     } else {
       log = inputData
     }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -76,5 +76,22 @@ test('cli', (t) => {
     t.tearDown(() => child.kill())
   })
 
+  t.test('passes through stringified date as string', (t) => {
+    t.plan(1)
+    const child = spawn(process.argv0, [bin])
+    child.on('error', t.threw)
+
+    const date = JSON.stringify(new Date(epoch))
+
+    child.stdout.on('data', (data) => {
+      t.is(data.toString(), date + '\n')
+    })
+
+    child.stdin.write(date)
+    child.stdin.write('\n')
+
+    t.tearDown(() => child.kill())
+  })
+
   t.end()
 })


### PR DESCRIPTION
* Add test for passing through double-quoted string from JSON.stringify(new Date())
* Check for parsed value being JS object, otherwise just fallthrough as on parse error