### PR TITLE
feat: support custom key prettifiers as option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -63,7 +63,7 @@ pino app.js | pino-pretty
 - `--messageKey` (`-m`): Define the key that contains the main log message.
   Default: `msg`.
 - `--timestampKey` (`-m`): Define the key that contains the log timestamp.
-  Default: `time`.  
+  Default: `time`.
 - `--translateTime` (`-t`): Translate the epoch time value into a human readable
   date and time string. This flag also can set the format string to apply when
   translating the date to human readable format. For a list of available pattern
@@ -129,12 +129,28 @@ with keys corresponding to the options described in [CLI Arguments](#cliargs):
   timestampKey: 'time', // --timestampKey
   translateTime: false, // --translateTime
   search: 'foo == `bar`', // --search
-  ignore: 'pid,hostname' // --ignore
+  ignore: 'pid,hostname' // --ignore,
+  customPrettifiers: {}
 }
 ```
 
 The `colorize` default follows
 [`chalk.supportsColor`](https://www.npmjs.com/package/chalk#chalksupportscolor).
+
+`customPrettifiers` option provides the ability to add a custom prettify function
+for specific log properties. `customPrettifiers` is an object, where keys are log properties which will be prettified and value is the prettify function itself. For example, if log has contains `query` property,
+you can specify a prettifier for it:
+```js
+{
+  customPrettifiers: {
+    query: prettifyQuery
+  }
+}
+//...
+const prettifyQuery = value => {
+  // do some prettify magic
+}
+```
 
 <a id="license"><a>
 ## License

--- a/Readme.md
+++ b/Readme.md
@@ -138,7 +138,9 @@ The `colorize` default follows
 [`chalk.supportsColor`](https://www.npmjs.com/package/chalk#chalksupportscolor).
 
 `customPrettifiers` option provides the ability to add a custom prettify function
-for specific log properties. `customPrettifiers` is an object, where keys are log properties which will be prettified and value is the prettify function itself. For example, if log has contains `query` property,
+for specific log properties. `customPrettifiers` is an object, where keys are
+log properties which will be prettified and value is the prettify function itself.
+For example, if a log line contains a `query` propert
 you can specify a prettifier for it:
 ```js
 {

--- a/index.js
+++ b/index.js
@@ -87,13 +87,10 @@ module.exports = function prettyFactory (options) {
     const prettifiedMessage = prettifyMessage({ log, messageKey, colorizer })
     const prettifiedMetadata = prettifyMetadata({ log })
     const prettifiedTime = prettifyTime({ log, translateFormat: opts.translateTime, timestampKey })
-    const customPrettifiedProps = []
+    const prettifiedProps = []
 
     if (opts.customPrettifiers.length) {
-      opts.customPrettifiers.forEach(prettifier => {
-        const { prettify, key } = prettifier
-        customPrettifiedProps.push(prettify({ log, key }))
-      })
+      opts.customPrettifiers.forEach(({ prettify, key }) => prettifiedProps.push(prettify({ log, key })))
     }
 
     let line = ''
@@ -127,8 +124,8 @@ module.exports = function prettyFactory (options) {
       line = `${line} ${prettifiedMessage}`
     }
 
-    if (customPrettifiedProps.length) {
-      line = `${line} ${customPrettifiedProps.join(' ')}`
+    if (prettifiedProps.length) {
+      line = `${line} ${prettifiedProps.join(' ')}`
     }
 
     if (line.length > 0) {

--- a/index.js
+++ b/index.js
@@ -90,7 +90,11 @@ module.exports = function prettyFactory (options) {
     const prettifiedProps = []
 
     if (opts.customPrettifiers.length) {
-      opts.customPrettifiers.forEach(({ prettify, key }) => prettifiedProps.push(prettify({ log, key })))
+      opts.customPrettifiers.forEach(({ prettify, key }) => {
+        if (log[key]) {
+          prettifiedProps.push(prettify({ log, key }))
+        }
+      })
     }
 
     let line = ''
@@ -143,7 +147,7 @@ module.exports = function prettyFactory (options) {
       line += prettifiedErrorLog
     } else {
       const customPrettifiedKeys = opts.customPrettifiers.length
-        ? opts.customPrettifiers.map(({ key }) => key)
+        ? opts.customPrettifiers.map(({ key }) => log[key] ? key : undefined)
         : []
       const skipKeys = [
         typeof log[messageKey] === 'string' && messageKey,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -282,13 +282,13 @@ function prettifyObject ({
 
     if (keyValue === undefined) continue
 
-    let stringify = () => stringifySafe(keyValue, null, 2)
-    const customPrettifier = customPrettifiers[keyName]
-    if (typeof customPrettifier === 'function') {
-      stringify = () => customPrettifier(keyValue, keyName, input)
+    let lines
+    if (typeof customPrettifiers[keyName] === 'function') {
+      lines = customPrettifiers[keyName](keyValue, keyName, input)
+    } else {
+      lines = stringifySafe(keyValue, null, 2)
     }
 
-    const lines = stringify()
     if (lines === undefined) continue
     const joinedLines = joinLinesWithIndentation({ input: lines, ident, eol })
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -249,7 +249,7 @@ function prettifyMetadata ({ log }) {
  * @param {string} [input.eol] The EOL sequence to use. Default: `'\n'`.
  * @param {string[]} [input.skipKeys] A set of object keys to exclude from the
  * prettified result. Default: `[]`.
- * @param {{[key: string]: function}} [input.customPrettifiers] Dictionary of
+ * @param {Object<string, function>} [input.customPrettifiers] Dictionary of
  * custom prettifiers. Default: `{}`.
  * @param {string[]} [input.errorLikeKeys] A set of object keys that contain
  * error objects. Default: `ERROR_LIKE_KEYS` constant.

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -537,6 +537,25 @@ test('basic prettifier tests', (t) => {
     log.info({ msg })
   })
 
+  t.test('prettifies custom key', (t) => {
+    t.plan(1)
+    const pretty = prettyFactory({
+      customPrettifiers: [{
+        prettify: ({ log, key }) => {
+          return `${log[key]}baz`
+        },
+        key: 'foo'
+      }, {
+        prettify: ({ log, key }) => {
+          return log[key].toUpperCase()
+        },
+        key: 'cow'
+      }]
+    })
+    const arst = pretty('{"msg":"hello world", "foo": "bar", "cow": "moo", "level":30, "v":1}')
+    t.is(arst, 'INFO : hello world barbaz MOO\n')
+  })
+
   t.test('prettifies object with some undefined values', (t) => {
     t.plan(1)
     const dest = new Writable({

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -556,6 +556,25 @@ test('basic prettifier tests', (t) => {
     t.is(arst, 'INFO : hello world barbaz MOO\n')
   })
 
+  t.test('does not prettify custom key that does not exists', (t) => {
+    t.plan(1)
+    const pretty = prettyFactory({
+      customPrettifiers: [{
+        prettify: ({ log, key }) => {
+          return `${log[key]}baz`
+        },
+        key: 'foo'
+      }, {
+        prettify: ({ log, key }) => {
+          return log[key].toUpperCase()
+        },
+        key: 'baz'
+      }]
+    })
+    const arst = pretty('{"msg":"hello world", "foo": "bar", "level":30, "v":1}')
+    t.is(arst, 'INFO : hello world barbaz\n')
+  })
+
   t.test('prettifies object with some undefined values', (t) => {
     t.plan(1)
     const dest = new Writable({


### PR DESCRIPTION
### This PR
- [x] Adds an option to `pino-pretty` for custom key prettifiers
- [x] Updates test to cover the functionality

### Note
The reasoning behind this is that `pino-pretty` can be extended to cover  some uses cases of log outputs that provide additional keywords. Main example would be `sequelize` which log provides the `query` property on the log output. Using `customPrettifiers` option that content of `query` prop can be prettified and formatted. 

This would eliminate the need for writing a custom prettifier for `pino` for these simple cases. 