### PR TITLE
feat: add messageFormat option for msg

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -62,6 +62,8 @@ pino app.js | pino-pretty
   error like objects. Default: `err,error`.
 - `--messageKey` (`-m`): Define the key that contains the main log message.
   Default: `msg`.
+- `--messageFormat` (`-o`): Format output of message, e.g. `{level} - {pid}` will output message: `INFO - 1123`
+  Default: `false`
 - `--timestampKey` (`-m`): Define the key that contains the log timestamp.
   Default: `time`.
 - `--translateTime` (`-t`): Translate the epoch time value into a human readable
@@ -126,6 +128,7 @@ with keys corresponding to the options described in [CLI Arguments](#cliargs):
   errorProps: '', // --errorProps
   levelFirst: false, // --levelFirst
   messageKey: 'msg', // --messageKey
+  messageFormat: false // --messageFormat
   timestampKey: 'time', // --timestampKey
   translateTime: false, // --translateTime
   search: 'foo == `bar`', // --search

--- a/bin.js
+++ b/bin.js
@@ -15,6 +15,7 @@ args
   .option(['l', 'levelFirst'], 'Display the log level as the first output field')
   .option(['k', 'errorLikeObjectKeys'], 'Define which keys contain error objects (`-k err,error`)', 'err,error')
   .option(['m', 'messageKey'], 'Highlight the message under the specified key', CONSTANTS.MESSAGE_KEY)
+  .option(['o', 'messageFormat'], 'Format output of message')
   .option(['a', 'timestampKey'], 'Display the timestamp from the specified key', CONSTANTS.TIMESTAMP_KEY)
   .option(['t', 'translateTime'], 'Display epoch timestamps as UTC ISO format or according to an optional format string (default ISO 8601)')
   .option(['s', 'search'], 'Specify a search pattern according to jmespath')

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ const defaultOptions = {
   errorProps: '',
   levelFirst: false,
   messageKey: MESSAGE_KEY,
+  messageFormat: false,
   timestampKey: TIMESTAMP_KEY,
   translateTime: false,
   useMetadata: false,
@@ -42,6 +43,7 @@ module.exports = function prettyFactory (options) {
   const EOL = opts.crlf ? '\r\n' : '\n'
   const IDENT = '    '
   const messageKey = opts.messageKey
+  const messageFormat = opts.messageFormat
   const timestampKey = opts.timestampKey
   const errorLikeObjectKeys = opts.errorLikeObjectKeys
   const errorProps = opts.errorProps.split(',')
@@ -75,6 +77,8 @@ module.exports = function prettyFactory (options) {
       return
     }
 
+    const prettifiedMessage = prettifyMessage({ log, messageKey, colorizer, messageFormat })
+
     if (ignoreKeys) {
       log = Object.keys(log)
         .filter(key => !ignoreKeys.has(key))
@@ -85,7 +89,6 @@ module.exports = function prettyFactory (options) {
     }
 
     const prettifiedLevel = prettifyLevel({ log, colorizer })
-    const prettifiedMessage = prettifyMessage({ log, messageKey, colorizer })
     const prettifiedMetadata = prettifyMetadata({ log })
     const prettifiedTime = prettifyTime({ log, translateFormat: opts.translateTime, timestampKey })
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -186,6 +186,8 @@ function prettifyLevel ({ log, colorizer = defaultColorizer }) {
  * @param {object} input.log The log object with the message to colorize.
  * @param {string} [input.messageKey='msg'] The property of the `log` that is the
  * message to be prettified.
+ * @param {string} [input.messageFormat=false] An option defines the output of
+ * msg. Default: false
  * @param {function} [input.colorizer] A colorizer function that has a
  * `.message(str)` method attached to it. This function should return a colorized
  * string which will be the "prettified" message. Default: a no-op colorizer.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -196,7 +196,7 @@ function prettifyLevel ({ log, colorizer = defaultColorizer }) {
  */
 function prettifyMessage ({ log, messageFormat, messageKey = MESSAGE_KEY, colorizer = defaultColorizer }) {
   if (messageFormat) {
-    const message = messageFormat.replace(/{([^}]+)}/g, function (match, p1) {
+    const message = String(messageFormat).replace(/{([^{}]+)}/g, function (match, p1) {
       if (p1 && log[p1]) {
         return log[p1]
       }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -186,7 +186,8 @@ function prettifyLevel ({ log, colorizer = defaultColorizer }) {
  * @param {object} input.log The log object with the message to colorize.
  * @param {string} [input.messageKey='msg'] The property of the `log` that is the
  * message to be prettified.
- * @param {string} [input.messageFormat=false] An option defines the output of
+ * @param {string} [input.messageFormat=undefined] A format string that defines how the
+ *  logged message should be formatted, e.g. `'{level} - {pid}'`.
  * @param {function} [input.colorizer] A colorizer function that has a
  * `.message(str)` method attached to it. This function should return a colorized
  * string which will be the "prettified" message. Default: a no-op colorizer.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -187,7 +187,6 @@ function prettifyLevel ({ log, colorizer = defaultColorizer }) {
  * @param {string} [input.messageKey='msg'] The property of the `log` that is the
  * message to be prettified.
  * @param {string} [input.messageFormat=false] An option defines the output of
- * msg. Default: false
  * @param {function} [input.colorizer] A colorizer function that has a
  * `.message(str)` method attached to it. This function should return a colorized
  * string which will be the "prettified" message. Default: a no-op colorizer.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -194,7 +194,16 @@ function prettifyLevel ({ log, colorizer = defaultColorizer }) {
  * key is not a string, then `undefined` will be returned. Otherwise, a string
  * that is the prettified message.
  */
-function prettifyMessage ({ log, messageKey = MESSAGE_KEY, colorizer = defaultColorizer }) {
+function prettifyMessage ({ log, messageFormat, messageKey = MESSAGE_KEY, colorizer = defaultColorizer }) {
+  if (messageFormat) {
+    const message = messageFormat.replace(/{([^}]+)}/g, function (match, p1) {
+      if (p1 && log[p1]) {
+        return log[p1]
+      }
+      return ''
+    })
+    return colorizer.message(message)
+  }
   if (messageKey in log === false) return undefined
   if (typeof log[messageKey] !== 'string') return undefined
   return colorizer.message(log[messageKey])

--- a/test/lib/utils.public.test.js
+++ b/test/lib/utils.public.test.js
@@ -91,6 +91,11 @@ tap.test('prettifyMessage', t => {
     t.is(str, '\u001B[36mfoo\u001B[39m')
   })
 
+  t.test('returns message formatted by `messageFormat` option', async t => {
+    const str = prettifyMessage({ log: { msg: 'foo', context: 'appModule' }, messageFormat: '{context} - {msg}' })
+    t.is(str, 'appModule - foo')
+  })
+
   t.end()
 })
 

--- a/test/lib/utils.public.test.js
+++ b/test/lib/utils.public.test.js
@@ -96,6 +96,11 @@ tap.test('prettifyMessage', t => {
     t.is(str, 'appModule - foo')
   })
 
+  t.test('`messageFormat` supports nested curly brackets', async t => {
+    const str = prettifyMessage({ log: { level: 30 }, messageFormat: '{{level}}-{level}-{{level}-{level}}' })
+    t.is(str, '{30}-30-{30-30}')
+  })
+
   t.end()
 })
 


### PR DESCRIPTION
Add `messageFormat` for combining some useful log properties into `msg`. And combined properties can be ignored.

Since `pino-pretty` is recommended for development only,  may `messageFormat` is a flexible way for module, for example:

```js
// log
{
  module: 'repository',
  msg: 'foo'
}

// options
{
  messageFormat: '[{module}] - {msg}',
  ignore: 'module',
}
```

The result will be `[repository] - foo`.