### PR TITLE
Prettify `caller` property

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -36,6 +36,7 @@ module.exports = {
     'level',
     'time',
     'timestamp',
-    'v'
+    'v',
+    'caller'
   ]
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -246,7 +246,7 @@ function prettifyMetadata ({ log }) {
     line += ')'
 
     if (log.caller) {
-      line += `<${log.caller}>`
+      line += ` <${log.caller}>`
     }
 
     return line

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -244,6 +244,11 @@ function prettifyMetadata ({ log }) {
     }
 
     line += ')'
+
+    if (log.caller) {
+      line += `<${log.caller}>`
+    }
+
     return line
   }
   return undefined


### PR DESCRIPTION
If the `caller` property exists (like from [pino-caller](https://github.com/pinojs/pino-caller)), include it in the info line. 

![Screenshot from 2019-11-25 17-57-38](https://user-images.githubusercontent.com/168240/69593147-2dc70d00-0fad-11ea-988d-779e378c6b93.png)
