### PR TITLE
Add --changeLevelName option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -62,6 +62,8 @@ pino app.js | pino-pretty
   error like objects. Default: `err,error`.
 - `--messageKey` (`-m`): Define the key that contains the main log message.
   Default: `msg`.
+- `--levelKey` (`--levelKey`): Define the key that contains the level of the log.
+  Default: `level`.
 - `--messageFormat` (`-o`): Format output of message, e.g. `{level} - {pid}` will output message: `INFO - 1123`
   Default: `false`
 - `--timestampKey` (`-m`): Define the key that contains the log timestamp.
@@ -129,6 +131,7 @@ with keys corresponding to the options described in [CLI Arguments](#cliargs):
   errorProps: '', // --errorProps
   levelFirst: false, // --levelFirst
   messageKey: 'msg', // --messageKey
+  levelKey: 'level', // --levelKey
   messageFormat: false // --messageFormat
   timestampKey: 'time', // --timestampKey
   translateTime: false, // --translateTime

--- a/bin.js
+++ b/bin.js
@@ -38,6 +38,7 @@ args
   .option(['l', 'levelFirst'], 'Display the log level as the first output field')
   .option(['k', 'errorLikeObjectKeys'], 'Define which keys contain error objects (`-k err,error`)', 'err,error')
   .option(['m', 'messageKey'], 'Highlight the message under the specified key', CONSTANTS.MESSAGE_KEY)
+  .option('levelKey', 'Detect the log level under the specified key', CONSTANTS.LEVEL_KEY)
   .option(['o', 'messageFormat'], 'Format output of message')
   .option(['a', 'timestampKey'], 'Display the timestamp from the specified key', CONSTANTS.TIMESTAMP_KEY)
   .option(['t', 'translateTime'], 'Display epoch timestamps as UTC ISO format or according to an optional format string (default ISO 8601)')
@@ -48,6 +49,7 @@ args
 args
   .example('cat log | pino-pretty', 'To prettify logs, simply pipe a log file through')
   .example('cat log | pino-pretty -m fooMessage', 'To highlight a string at a key other than \'msg\', use')
+  .example('cat log | pino-pretty --levelKey fooLevel', 'To detect the log level at a key other than \'level\', use')
   .example('cat log | pino-pretty -a fooTimestamp', 'To display timestamp from a key other than \'time\', use')
   .example('cat log | pino-pretty -t', 'To convert Epoch timestamps to ISO timestamps use the -t option')
   .example('cat log | pino-pretty -t "SYS:yyyy-mm-dd HH:MM:ss"', 'To convert Epoch timestamps to local timezone format use the -t option with "SYS:" prefixed format string')
@@ -62,10 +64,12 @@ let opts = args.parse(process.argv, {
   mri: {
     default: {
       messageKey: DEFAULT_VALUE,
+      levelKey: DEFAULT_VALUE,
       timestampKey: DEFAULT_VALUE
     }
   }
 })
+
 // Remove default values
 opts = filter(opts, value => value !== DEFAULT_VALUE)
 const config = loadConfig(opts.config)

--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ module.exports = function prettyFactory (options) {
   const EOL = opts.crlf ? '\r\n' : '\n'
   const IDENT = '    '
   const messageKey = opts.messageKey
+  const levelKey = opts.levelKey
   const messageFormat = opts.messageFormat
   const timestampKey = opts.timestampKey
   const errorLikeObjectKeys = opts.errorLikeObjectKeys
@@ -88,7 +89,7 @@ module.exports = function prettyFactory (options) {
         }, {})
     }
 
-    const prettifiedLevel = prettifyLevel({ log, colorizer })
+    const prettifiedLevel = prettifyLevel({ log, colorizer, levelKey })
     const prettifiedMetadata = prettifyMetadata({ log })
     const prettifiedTime = prettifyTime({ log, translateFormat: opts.translateTime, timestampKey })
 
@@ -137,7 +138,7 @@ module.exports = function prettyFactory (options) {
       })
       line += prettifiedErrorLog
     } else {
-      const skipKeys = typeof log[messageKey] === 'string' ? [messageKey] : undefined
+      const skipKeys = [messageKey, levelKey].filter(key => typeof log[key] === 'string')
       const prettifiedObject = prettifyObject({
         input: log,
         skipKeys,

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -7,6 +7,8 @@ module.exports = {
 
   MESSAGE_KEY: 'msg',
 
+  LEVEL_KEY: 'level',
+
   TIMESTAMP_KEY: 'time',
 
   LEVELS: {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,6 +7,7 @@ const {
   DATE_FORMAT,
   ERROR_LIKE_KEYS,
   MESSAGE_KEY,
+  LEVEL_KEY,
   TIMESTAMP_KEY,
   LOGGER_KEYS
 } = require('./constants')
@@ -166,17 +167,18 @@ function prettifyErrorLog ({
  * string for that level if so.
  *
  * @param {object} input
- * @param {object} input.log The log object which should have a `level` property.
+ * @param {object} input.log The log object.
  * @param {function} [input.colorizer] A colorizer function that accepts a level
  * value and returns a colorized string. Default: a no-op colorizer.
+ * @param {string} [levelKey='level'] The key to find the level under.
  *
  * @returns {undefined|string} If `log` does not have a `level` property then
  * `undefined` will be returned. Otherwise, a string from the specified
  * `colorizer` is returned.
  */
-function prettifyLevel ({ log, colorizer = defaultColorizer }) {
-  if ('level' in log === false) return undefined
-  return colorizer(log.level)
+function prettifyLevel ({ log, colorizer = defaultColorizer, levelKey = LEVEL_KEY }) {
+  if (levelKey in log === false) return undefined
+  return colorizer(log[levelKey])
 }
 
 /**

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -105,6 +105,22 @@ test('basic prettifier tests', (t) => {
     log.info({ bar: 'baz' })
   })
 
+  t.test('can use different level keys', (t) => {
+    t.plan(1)
+    const pretty = prettyFactory({ levelKey: 'bar' })
+    const log = pino({}, new Writable({
+      write (chunk, enc, cb) {
+        const formatted = pretty(chunk.toString())
+        t.is(
+          formatted,
+          `[${epoch}] WARN  (${pid} on ${hostname}): foo\n`
+        )
+        cb()
+      }
+    }))
+    log.info({ msg: 'foo', bar: 'warn' })
+  })
+
   t.test('will format time to UTC', (t) => {
     t.plan(1)
     const pretty = prettyFactory({ translateTime: true })


### PR DESCRIPTION
This would resolve https://github.com/pinojs/pino-pretty/issues/91

I've named the option `changeLevelName` to be in line with the option in pino.
I wasn't too sure about the short form for `--changeLevelName`, since both `-c` and `-l` were already used, so right now there is no short form.