### PR TITLE
Prettify Time Before Filtering

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,6 +74,7 @@ module.exports = function prettyFactory (options) {
     }
 
     const prettifiedMessage = prettifyMessage({ log, messageKey, colorizer, messageFormat })
+    const prettifiedTime = prettifyTime({ log, translateFormat: opts.translateTime, timestampKey })
 
     if (ignoreKeys) {
       log = Object.keys(log)
@@ -86,7 +87,6 @@ module.exports = function prettyFactory (options) {
 
     const prettifiedLevel = prettifyLevel({ log, colorizer, levelKey })
     const prettifiedMetadata = prettifyMetadata({ log })
-    const prettifiedTime = prettifyTime({ log, translateFormat: opts.translateTime, timestampKey })
 
     let line = ''
     if (opts.levelFirst && prettifiedLevel) {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -643,5 +643,19 @@ test('basic prettifier tests', (t) => {
     log.info('foo')
   })
 
+  t.test('handles specified timestampKey', (t) => {
+    t.plan(1)
+    const pretty = prettyFactory({ timestampKey: '@timestamp' })
+    const arst = pretty(`{"msg":"hello world", "@timestamp":${epoch}, "level":30}`)
+    t.is(arst, `[${epoch}] INFO : hello world\n    @timestamp: ${epoch}\n`)
+  })
+
+  t.test('handles using ignored timestampKey', (t) => {
+    t.plan(1)
+    const pretty = prettyFactory({ timestampKey: '@timestamp', ignore: '@timestamp' })
+    const arst = pretty(`{"msg":"hello world", "@timestamp":${epoch}, "level":30}`)
+    t.is(arst, `[${epoch}] INFO : hello world\n`)
+  })
+
   t.end()
 })

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -101,7 +101,7 @@ test('cli', (t) => {
   })
 
   t.test('uses specified timestampKey', (t) => {
-    t.plan(1);
+    t.plan(1)
     const env = { TERM: 'dumb' }
     const child = spawn(process.argv[0], [bin, '--timestampKey', '@timestamp'], { env })
     child.on('error', t.threw)
@@ -111,10 +111,10 @@ test('cli', (t) => {
     const logLine = '{"level":30,"@timestamp":1522431328992,"msg":"hello world"}\n'
     child.stdin.write(logLine)
     t.tearDown(() => child.kill())
-  });
+  })
 
   t.test('uses an ignored timestampKey', (t) => {
-    t.plan(1);
+    t.plan(1)
     const env = { TERM: 'dumb' }
     const child = spawn(process.argv[0], [bin, '--timestampKey', '@timestamp', '--ignore', '@timestamp'], { env })
     child.on('error', t.threw)
@@ -124,7 +124,7 @@ test('cli', (t) => {
     const logLine = '{"level":30,"@timestamp":1522431328992,"msg":"hello world"}\n'
     child.stdin.write(logLine)
     t.tearDown(() => child.kill())
-  });
+  })
 
   t.end()
 })

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -100,5 +100,31 @@ test('cli', (t) => {
     t.tearDown(() => child.kill())
   })
 
+  t.test('uses specified timestampKey', (t) => {
+    t.plan(1);
+    const env = { TERM: 'dumb' }
+    const child = spawn(process.argv[0], [bin, '--timestampKey', '@timestamp'], { env })
+    child.on('error', t.threw)
+    child.stdout.on('data', (data) => {
+      t.is(data.toString(), '[1522431328992] INFO : hello world\n    @timestamp: 1522431328992\n')
+    })
+    const logLine = '{"level":30,"@timestamp":1522431328992,"msg":"hello world"}\n'
+    child.stdin.write(logLine)
+    t.tearDown(() => child.kill())
+  });
+
+  t.test('uses an ignored timestampKey', (t) => {
+    t.plan(1);
+    const env = { TERM: 'dumb' }
+    const child = spawn(process.argv[0], [bin, '--timestampKey', '@timestamp', '--ignore', '@timestamp'], { env })
+    child.on('error', t.threw)
+    child.stdout.on('data', (data) => {
+      t.is(data.toString(), '[1522431328992] INFO : hello world\n')
+    })
+    const logLine = '{"level":30,"@timestamp":1522431328992,"msg":"hello world"}\n'
+    child.stdin.write(logLine)
+    t.tearDown(() => child.kill())
+  });
+
   t.end()
 })


### PR DESCRIPTION
This allows the prettifiedTime function run before any of the properties are filtered from the log object. If you are using a timestampKey that is also ignored it will still work.

Issue described in: https://github.com/pinojs/pino-pretty/issues/116