### PR TITLE
Revert "Prettify Time Before Filtering (#117)"

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,6 @@ module.exports = function prettyFactory (options) {
     }
 
     const prettifiedMessage = prettifyMessage({ log, messageKey, colorizer, messageFormat })
-    const prettifiedTime = prettifyTime({ log, translateFormat: opts.translateTime, timestampKey })
 
     if (ignoreKeys) {
       log = Object.keys(log)
@@ -87,6 +86,7 @@ module.exports = function prettyFactory (options) {
 
     const prettifiedLevel = prettifyLevel({ log, colorizer, levelKey })
     const prettifiedMetadata = prettifyMetadata({ log })
+    const prettifiedTime = prettifyTime({ log, translateFormat: opts.translateTime, timestampKey })
 
     let line = ''
     if (opts.levelFirst && prettifiedLevel) {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -643,19 +643,5 @@ test('basic prettifier tests', (t) => {
     log.info('foo')
   })
 
-  t.test('handles specified timestampKey', (t) => {
-    t.plan(1)
-    const pretty = prettyFactory({ timestampKey: '@timestamp' })
-    const arst = pretty(`{"msg":"hello world", "@timestamp":${epoch}, "level":30}`)
-    t.is(arst, `[${epoch}] INFO : hello world\n    @timestamp: ${epoch}\n`)
-  })
-
-  t.test('handles using ignored timestampKey', (t) => {
-    t.plan(1)
-    const pretty = prettyFactory({ timestampKey: '@timestamp', ignore: '@timestamp' })
-    const arst = pretty(`{"msg":"hello world", "@timestamp":${epoch}, "level":30}`)
-    t.is(arst, `[${epoch}] INFO : hello world\n`)
-  })
-
   t.end()
 })

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -614,6 +614,13 @@ test('basic prettifier tests', (t) => {
     t.is(arst, `[${epoch}] INFO  (on ${hostname}): hello world\n`)
   })
 
+  t.test('ignores time', (t) => {
+    t.plan(1)
+    const pretty = prettyFactory({ ignore: 'time' })
+    const arst = pretty(`{"msg":"hello world", "pid":"${pid}", "hostname":"${hostname}", "time":${epoch}, "level":30, "v":1}`)
+    t.is(arst, `INFO  (${pid} on ${hostname}): hello world\n`)
+  })
+
   t.test('prettifies trace caller', (t) => {
     t.plan(1)
     const traceCaller = (instance) => {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -100,31 +100,5 @@ test('cli', (t) => {
     t.tearDown(() => child.kill())
   })
 
-  t.test('uses specified timestampKey', (t) => {
-    t.plan(1)
-    const env = { TERM: 'dumb' }
-    const child = spawn(process.argv[0], [bin, '--timestampKey', '@timestamp'], { env })
-    child.on('error', t.threw)
-    child.stdout.on('data', (data) => {
-      t.is(data.toString(), '[1522431328992] INFO : hello world\n    @timestamp: 1522431328992\n')
-    })
-    const logLine = '{"level":30,"@timestamp":1522431328992,"msg":"hello world"}\n'
-    child.stdin.write(logLine)
-    t.tearDown(() => child.kill())
-  })
-
-  t.test('uses an ignored timestampKey', (t) => {
-    t.plan(1)
-    const env = { TERM: 'dumb' }
-    const child = spawn(process.argv[0], [bin, '--timestampKey', '@timestamp', '--ignore', '@timestamp'], { env })
-    child.on('error', t.threw)
-    child.stdout.on('data', (data) => {
-      t.is(data.toString(), '[1522431328992] INFO : hello world\n')
-    })
-    const logLine = '{"level":30,"@timestamp":1522431328992,"msg":"hello world"}\n'
-    child.stdin.write(logLine)
-    t.tearDown(() => child.kill())
-  })
-
   t.end()
 })


### PR DESCRIPTION
This reverts commit 38beec137545b9fb7564f5f5f5d3c8a27fcbb9bd.

@BenGale unfortunately #117 broke pino-multi-stream and other (see https://github.com/pinojs/pino-multi-stream/pull/38)

The problem of the change in #117 is that it disables the ability to remove the timestamp from the main log line. I guess you'll have to file a different issue to solve your problem.

I've also added a regression test.