### PR TITLE
Skip timestampKey in Prettified Object

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,7 +133,7 @@ module.exports = function prettyFactory (options) {
       })
       line += prettifiedErrorLog
     } else {
-      const skipKeys = [messageKey, levelKey].filter(key => typeof log[key] === 'string')
+      const skipKeys = [messageKey, levelKey, timestampKey].filter(key => typeof log[key] === 'string' || typeof log[key] === 'number')
       const prettifiedObject = prettifyObject({
         input: log,
         skipKeys,

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -650,5 +650,12 @@ test('basic prettifier tests', (t) => {
     log.info('foo')
   })
 
+  t.test('handles specified timestampKey', (t) => {
+    t.plan(1)
+    const pretty = prettyFactory({ timestampKey: '@timestamp' })
+    const arst = pretty(`{"msg":"hello world", "@timestamp":${epoch}, "level":30}`)
+    t.is(arst, `[${epoch}] INFO : hello world\n`)
+  })
+
   t.end()
 })

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -100,5 +100,18 @@ test('cli', (t) => {
     t.tearDown(() => child.kill())
   })
 
+  t.test('uses specified timestampKey', (t) => {
+    t.plan(1)
+    const env = { TERM: 'dumb' }
+    const child = spawn(process.argv[0], [bin, '--timestampKey', '@timestamp'], { env })
+    child.on('error', t.threw)
+    child.stdout.on('data', (data) => {
+      t.is(data.toString(), '[1522431328992] INFO : hello world\n')
+    })
+    const logLine = '{"level":30,"@timestamp":1522431328992,"msg":"hello world"}\n'
+    child.stdin.write(logLine)
+    t.tearDown(() => child.kill())
+  })
+
   t.end()
 })


### PR DESCRIPTION
@mcollina This is related to: https://github.com/pinojs/pino-pretty/pull/119

I took another look at a better way for this to be handled and it seems like there is already something handling overrides for the messageKey and the levelKey, so I have extended that to also support timestampKey. Apologies for not spotting this on the first fix PR.

There are tests to cover this and make sure it isn't outputted in the prettified object.