### PR TITLE
🚧 multiline option

### DIFF
--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -657,5 +657,19 @@ test('basic prettifier tests', (t) => {
     t.is(arst, `[${epoch}] INFO : hello world\n`)
   })
 
+  t.test('multiline: false', (t) => {
+    t.plan(1)
+    const pretty = prettyFactory({ multiline: false, colorize: true })
+    const log = pino({}, new Writable({
+      write (chunk, enc, cb) {
+        const formatted = pretty(chunk.toString())
+        t.is(formatted, `[${epoch}] \u001B[32mINFO \u001B[39m (${pid} on ${hostname}): \u001B[36m{ b: { c: 'd' } }\u001B[39m \x1B[90m{ extra: { foo: 'bar', number: 42 } }\x1B[39m\n`)
+
+        cb()
+      }
+    }))
+    log.info({ msg: { b: { c: 'd' } }, extra: { foo: 'bar', number: 42 } })
+  })
+
   t.end()
 })

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -113,5 +113,25 @@ test('cli', (t) => {
     t.tearDown(() => child.kill())
   })
 
+  t.test('multiline: false', (t) => {
+    t.plan(1)
+
+    const logLineWithExtra = JSON.stringify(Object.assign(JSON.parse(logLine), {
+      extra: {
+        foo: 'bar',
+        number: 42
+      }
+    }))
+
+    const env = { TERM: 'dumb' }
+    const child = spawn(process.argv[0], [bin, '--multiline', 'false'], { env })
+    child.on('error', t.threw)
+    child.stdout.on('data', (data) => {
+      t.is(data.toString(), `[${epoch}] INFO  (42 on foo): hello world { extra: { foo: 'bar', number: 42 } }\n`)
+    })
+    child.stdin.write(logLineWithExtra)
+    t.tearDown(() => child.kill())
+  })
+
   t.end()
 })


### PR DESCRIPTION
I've added failing test so we can discuss the way we want to address #97 

I would suggest to add a `multiline` option so we can release this as a feature release, then change the default from `false` to `true` as part of v5

eventually fixes #97