### PR TITLE
Avoid adding spaces at the beginning of the line, fixes #129

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,11 @@ module.exports = function prettyFactory (options) {
     }
 
     if (prettifiedMetadata) {
-      line = `${line} ${prettifiedMetadata}:`
+      if (line.length > 0) {
+        line = `${line} ${prettifiedMetadata}:`
+      } else {
+        line = prettifiedMetadata
+      }
     }
 
     if (line.endsWith(':') === false && line !== '') {
@@ -116,7 +120,11 @@ module.exports = function prettyFactory (options) {
     }
 
     if (prettifiedMessage) {
-      line = `${line} ${prettifiedMessage}`
+      if (line.length > 0) {
+        line = `${line} ${prettifiedMessage}`
+      } else {
+        line = prettifiedMessage
+      }
     }
 
     if (line.length > 0) {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -621,6 +621,20 @@ test('basic prettifier tests', (t) => {
     t.is(arst, `INFO  (${pid} on ${hostname}): hello world\n`)
   })
 
+  t.test('ignores time and level', (t) => {
+    t.plan(1)
+    const pretty = prettyFactory({ ignore: 'time,level' })
+    const arst = pretty(`{"msg":"hello world", "pid":"${pid}", "hostname":"${hostname}", "time":${epoch}, "level":30}`)
+    t.is(arst, `(${pid} on ${hostname}): hello world\n`)
+  })
+
+  t.test('ignores all keys but message', (t) => {
+    t.plan(1)
+    const pretty = prettyFactory({ ignore: 'time,level,name,pid,hostname' })
+    const arst = pretty(`{"msg":"hello world", "pid":"${pid}", "hostname":"${hostname}", "time":${epoch}, "level":30}`)
+    t.is(arst, 'hello world\n')
+  })
+
   t.test('prettifies trace caller', (t) => {
     t.plan(1)
     const traceCaller = (instance) => {


### PR DESCRIPTION
Here is my fix for issue #129. There were two spots in pretty() where it was adding a space, even if the line to that point was empty, so I added tests for and fixed both.