### PR TITLE
Unblock logs on jmespath search error

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ module.exports = function prettyFactory (options) {
         return
       }
     } catch (error) {
-      console.error(`Unable to search current log ${JSON.stringify(log)} due to ${error}`);
+      console.error(`Unable to search current log ${JSON.stringify(log)} due to ${error}`)
       return
     }
 

--- a/index.js
+++ b/index.js
@@ -70,7 +70,11 @@ module.exports = function prettyFactory (options) {
       log = inputData
     }
 
-    if (search && !jmespath.search(log, search)) {
+    try {
+      if (search && !jmespath.search(log, search)) {
+        return
+      }
+    } catch (error) {
       return
     }
 

--- a/index.js
+++ b/index.js
@@ -75,6 +75,7 @@ module.exports = function prettyFactory (options) {
         return
       }
     } catch (error) {
+      console.error(`Unable to search current log ${JSON.stringify(log)} due to ${error}`);
       return
     }
 


### PR DESCRIPTION
Right now pino-pretty will break when it encounters any `jmespath.search` error.
Instead of breaking the entire tool while continuously tailing logs, it should continue through processing the rest of the logs and notify users when it can't process the log.