### PR TITLE
(docs) fix example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -47,7 +47,7 @@ It's recommended to use `pino-pretty` with `pino`
 by piping output to the CLI tool:
 
 ```sh
-pino app.js | pino-pretty
+node app.js | pino-pretty
 ```
 
 <a id="cliargs"></a>


### PR DESCRIPTION
`pino` isn't a command 