### PR TITLE
feature: Add a flag to hide object from output (--hideObject)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -82,6 +82,7 @@ node app.js | pino-pretty
 - `--search` (`-s`): Specify a search pattern according to
   [jmespath](http://jmespath.org/).
 - `--ignore` (`-i`): Ignore one or several keys: (`-i time,hostname`)
+- `--hideObject` (`-H`): Hide objects from output (but not error object)
 - `--config`: Specify a path to a config file containing the pino-pretty options.  pino-pretty will attempt to read from a `.pino-prettyrc` in your current directory (`process.cwd`) if not specified
 
 <a id="integration"></a>
@@ -139,7 +140,8 @@ with keys corresponding to the options described in [CLI Arguments](#cliargs):
   timestampKey: 'time', // --timestampKey
   translateTime: false, // --translateTime
   search: 'foo == `bar`', // --search
-  ignore: 'pid,hostname' // --ignore,
+  ignore: 'pid,hostname', // --ignore,
+  hideObject: false // --hideObject
   customPrettifiers: {}
 }
 ```

--- a/bin.js
+++ b/bin.js
@@ -45,6 +45,7 @@ args
   .option(['t', 'translateTime'], 'Display epoch timestamps as UTC ISO format or according to an optional format string (default ISO 8601)')
   .option(['s', 'search'], 'Specify a search pattern according to jmespath')
   .option(['i', 'ignore'], 'Ignore one or several keys: (`-i time,hostname`)')
+  .option(['H', 'hideObject'], 'Hide objects from output (but not error object)')
   .option('config', 'specify a path to a json file containing the pino-pretty options')
 
 args

--- a/index.js
+++ b/index.js
@@ -35,7 +35,8 @@ const defaultOptions = {
   translateTime: false,
   useMetadata: false,
   outputStream: process.stdout,
-  customPrettifiers: {}
+  customPrettifiers: {},
+  hideObject: false
 }
 
 module.exports = function prettyFactory (options) {
@@ -51,6 +52,7 @@ module.exports = function prettyFactory (options) {
   const errorProps = opts.errorProps.split(',')
   const customPrettifiers = opts.customPrettifiers
   const ignoreKeys = opts.ignore ? new Set(opts.ignore.split(',')) : undefined
+  const hideObject = opts.hideObject
 
   const colorizer = colors(opts.colorize)
   const search = opts.search
@@ -141,7 +143,7 @@ module.exports = function prettyFactory (options) {
         eol: EOL
       })
       line += prettifiedErrorLog
-    } else {
+    } else if (!hideObject) {
       const skipKeys = [messageKey, levelKey, timestampKey].filter(key => typeof log[key] === 'string' || typeof log[key] === 'number')
       const prettifiedObject = prettifyObject({
         input: log,

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -684,5 +684,18 @@ test('basic prettifier tests', (t) => {
     log.info({ v: 1 })
   })
 
+  t.test('Hide object `{ key: "value" }` from output when flag `hideObject` is set', (t) => {
+    t.plan(1)
+    const pretty = prettyFactory({ hideObject: true })
+    const log = pino({}, new Writable({
+      write (chunk, enc, cb) {
+        const formatted = pretty(chunk.toString())
+        t.is(formatted, `[${epoch}] INFO\t (${pid} on ${hostname}):\n`)
+        cb()
+      }
+    }))
+    log.info({ key: 'value' })
+  })
+
   t.end()
 })

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -690,11 +690,11 @@ test('basic prettifier tests', (t) => {
     const log = pino({}, new Writable({
       write (chunk, enc, cb) {
         const formatted = pretty(chunk.toString())
-        t.is(formatted, `[${epoch}] INFO\t (${pid} on ${hostname}):\n`)
+        t.is(formatted, `[${epoch}] INFO\t (${pid} on ${hostname}): hello world\n`)
         cb()
       }
     }))
-    log.info({ key: 'value' })
+    log.info({ key: 'value' }, 'hello world')
   })
 
   t.end()


### PR DESCRIPTION
This PR adds the flag 'hideObject' that allows users to choose disabling the print of objects on logs (i.e `prettifyObject()` call). I tried to modify the least code as possible to meet this goal.