### PR TITLE
Support Winston Log Levels

### DIFF
--- a/lib/colors.js
+++ b/lib/colors.js
@@ -9,8 +9,10 @@ const plain = {
   50: nocolor,
   40: nocolor,
   30: nocolor,
+  35: nocolor,
   20: nocolor,
   10: nocolor,
+  5: nocolor,
   message: nocolor
 }
 
@@ -18,12 +20,14 @@ const chalk = require('chalk')
 const ctx = new chalk.Instance({ level: 3 })
 const colored = {
   default: ctx.white,
-  60: ctx.bgRed,
-  50: ctx.red,
-  40: ctx.yellow,
-  30: ctx.green,
-  20: ctx.blue,
-  10: ctx.grey,
+  60: ctx.bgRed, // fatal
+  50: ctx.red, // error
+  40: ctx.yellow, // warn
+  35: ctx.green, // notice (custom)
+  30: ctx.blue, // info
+  20: ctx.magenta, // debug
+  10: ctx.grey, // trace
+  5: ctx.grey, // silly (custom)
   message: ctx.cyan
 }
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -18,18 +18,22 @@ module.exports = {
     60: 'FATAL',
     50: 'ERROR',
     40: 'WARN',
+    35: 'NOTICE', // Custom
     30: 'INFO',
     20: 'DEBUG',
-    10: 'TRACE'
+    10: 'TRACE',
+    5: 'SILLY' // Custom
   },
 
   LEVEL_NAMES: {
     fatal: 60,
     error: 50,
     warn: 40,
+    notice: 35, // Custom
     info: 30,
     debug: 20,
-    trace: 10
+    trace: 10,
+    silly: 5 // Custom
   },
 
   // Object keys that probably came from a logger like Pino or Bunyan.

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -65,7 +65,7 @@ test('basic prettifier tests', (t) => {
         const formatted = pretty(chunk.toString())
         t.is(
           formatted,
-          `[${epoch}] \u001B[32mINFO\u001B[39m (${pid} on ${hostname}): \u001B[36mfoo\u001B[39m\n`
+          `[${epoch}] \u001B[34mINFO\u001B[39m (${pid} on ${hostname}): \u001B[36mfoo\u001B[39m\n`
         )
         cb()
       }
@@ -395,7 +395,7 @@ test('basic prettifier tests', (t) => {
   t.test('handles customLogLevel', (t) => {
     t.plan(1)
     const pretty = prettyFactory()
-    const log = pino({ customLevels: { testCustom: 35 } }, new Writable({
+    const log = pino({ customLevels: { testCustom: 36 } }, new Writable({
       write (chunk, enc, cb) {
         const formatted = pretty(chunk.toString())
         t.match(formatted, /USERLVL/)

--- a/test/lib/colors.test.js
+++ b/test/lib/colors.test.js
@@ -5,7 +5,10 @@ const getColorizer = require('../../lib/colors')
 
 test('returns default colorizer', async t => {
   const colorizer = getColorizer()
-  let colorized = colorizer(10)
+  let colorized = colorizer(5)
+  t.is(colorized, 'SILLY')
+
+  colorized = colorizer(10)
   t.is(colorized, 'TRACE')
 
   colorized = colorizer(20)
@@ -13,6 +16,9 @@ test('returns default colorizer', async t => {
 
   colorized = colorizer(30)
   t.is(colorized, 'INFO')
+
+  colorized = colorizer(35)
+  t.is(colorized, 'NOTICE')
 
   colorized = colorizer(40)
   t.is(colorized, 'WARN')
@@ -38,14 +44,20 @@ test('returns default colorizer', async t => {
 
 test('returns colorizing colorizer', async t => {
   const colorizer = getColorizer(true)
-  let colorized = colorizer(10)
+  let colorized = colorizer(5)
+  t.is(colorized, '\u001B[90mSILLY\u001B[39m')
+
+  colorized = colorizer(10)
   t.is(colorized, '\u001B[90mTRACE\u001B[39m')
 
   colorized = colorizer(20)
-  t.is(colorized, '\u001B[34mDEBUG\u001B[39m')
+  t.is(colorized, '\u001B[35mDEBUG\u001B[39m')
 
   colorized = colorizer(30)
-  t.is(colorized, '\u001B[32mINFO\u001B[39m')
+  t.is(colorized, '\u001B[34mINFO\u001B[39m')
+
+  colorized = colorizer(35)
+  t.is(colorized, '\u001B[32mNOTICE\u001B[39m')
 
   colorized = colorizer(40)
   t.is(colorized, '\u001B[33mWARN\u001B[39m')
@@ -60,7 +72,7 @@ test('returns colorizing colorizer', async t => {
   t.is(colorized, '\u001B[37mUSERLVL\u001B[39m')
 
   colorized = colorizer('info')
-  t.is(colorized, '\u001B[32mINFO\u001B[39m')
+  t.is(colorized, '\u001B[34mINFO\u001B[39m')
 
   colorized = colorizer('use-default')
   t.is(colorized, '\u001B[37mUSERLVL\u001B[39m')

--- a/test/lib/utils.public.test.js
+++ b/test/lib/utils.public.test.js
@@ -50,7 +50,7 @@ tap.test('prettifyLevel', t => {
     }
     const colorizer = getColorizer(true)
     const colorized = prettifyLevel({ log, colorizer })
-    t.is(colorized, '\u001B[32mINFO\u001B[39m')
+    t.is(colorized, '\u001B[34mINFO\u001B[39m')
   })
 
   t.end()


### PR DESCRIPTION
This introduces an out of the box experience that allows previous Winston users to map `NOTICE` and `SILLY` log levels. One simply needs to conform to setting the level values of:

- `35` for `NOTICE`
- `5` for `SILLY`
