### PR TITLE
Add `singleLine` config option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -85,6 +85,7 @@ node app.js | pino-pretty
   [jmespath](http://jmespath.org/).
 - `--ignore` (`-i`): Ignore one or several keys: (`-i time,hostname`)
 - `--hideObject` (`-H`): Hide objects from output (but not error object)
+- `--singleLine` (`-S`): Print each log message on a single line (errors will still be multi-line)
 - `--config`: Specify a path to a config file containing the pino-pretty options.  pino-pretty will attempt to read from a `.pino-prettyrc` in your current directory (`process.cwd`) if not specified
 
 <a id="integration"></a>
@@ -142,8 +143,9 @@ with keys corresponding to the options described in [CLI Arguments](#cliargs):
   timestampKey: 'time', // --timestampKey
   translateTime: false, // --translateTime
   search: 'foo == `bar`', // --search
-  ignore: 'pid,hostname', // --ignore,
-  hideObject: false // --hideObject
+  ignore: 'pid,hostname', // --ignore
+  hideObject: false, // --hideObject
+  singleLine: false, // --singleLine
   customPrettifiers: {}
 }
 ```

--- a/bin.js
+++ b/bin.js
@@ -46,6 +46,7 @@ args
   .option(['s', 'search'], 'Specify a search pattern according to jmespath')
   .option(['i', 'ignore'], 'Ignore one or several keys: (`-i time,hostname`)')
   .option(['H', 'hideObject'], 'Hide objects from output (but not error object)')
+  .option(['S', 'singleLine'], 'Print all non-error objects on a single line')
   .option('config', 'specify a path to a json file containing the pino-pretty options')
 
 args

--- a/index.js
+++ b/index.js
@@ -36,7 +36,8 @@ const defaultOptions = {
   useMetadata: false,
   outputStream: process.stdout,
   customPrettifiers: {},
-  hideObject: false
+  hideObject: false,
+  singleLine: false
 }
 
 module.exports = function prettyFactory (options) {
@@ -53,6 +54,7 @@ module.exports = function prettyFactory (options) {
   const customPrettifiers = opts.customPrettifiers
   const ignoreKeys = opts.ignore ? new Set(opts.ignore.split(',')) : undefined
   const hideObject = opts.hideObject
+  const singleLine = opts.singleLine
 
   const colorizer = colors(opts.colorize)
   const search = opts.search
@@ -131,7 +133,7 @@ module.exports = function prettyFactory (options) {
     }
 
     if (line.length > 0) {
-      line += EOL
+      line += (singleLine ? ' ' : EOL)
     }
 
     if (log.type === 'Error' && log.stack) {
@@ -151,7 +153,8 @@ module.exports = function prettyFactory (options) {
         customPrettifiers,
         errorLikeKeys: errorLikeObjectKeys,
         eol: EOL,
-        ident: IDENT
+        ident: IDENT,
+        singleLine
       })
       line += prettifiedObject
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,7 +26,8 @@ module.exports = {
 
 module.exports.internals = {
   formatTime,
-  joinLinesWithIndentation
+  joinLinesWithIndentation,
+  prettifyError
 }
 
 /**
@@ -291,6 +292,9 @@ function prettifyMetadata ({ log }) {
  * error objects. Default: `ERROR_LIKE_KEYS` constant.
  * @param {boolean} [input.excludeLoggerKeys] Indicates if known logger specific
  * keys should be excluded from prettification. Default: `true`.
+ * @param {boolean} [input.singleLine] Should non-error keys all be formatted
+ * on a single line? This does NOT apply to errors, which will still be
+ * multi-line. Default: `false`
  *
  * @returns {string} The prettified string. This can be as little as `''` if
  * there was nothing to prettify.
@@ -302,55 +306,63 @@ function prettifyObject ({
   skipKeys = [],
   customPrettifiers = {},
   errorLikeKeys = ERROR_LIKE_KEYS,
-  excludeLoggerKeys = true
+  excludeLoggerKeys = true,
+  singleLine = false
 }) {
-  const objectKeys = Object.keys(input)
   const keysToIgnore = [].concat(skipKeys)
 
   if (excludeLoggerKeys === true) Array.prototype.push.apply(keysToIgnore, LOGGER_KEYS)
 
   let result = ''
 
-  const keysToIterate = objectKeys.filter(k => keysToIgnore.includes(k) === false)
-  for (let i = 0; i < objectKeys.length; i += 1) {
-    const keyName = keysToIterate[i]
-    const keyValue = input[keyName]
-
-    if (keyValue === undefined) continue
-
-    let lines
-    if (typeof customPrettifiers[keyName] === 'function') {
-      lines = customPrettifiers[keyName](keyValue, keyName, input)
-    } else {
-      lines = stringifySafe(keyValue, null, 2)
-    }
-
-    if (lines === undefined) continue
-    const joinedLines = joinLinesWithIndentation({ input: lines, ident, eol })
-
-    if (errorLikeKeys.includes(keyName) === true) {
-      const splitLines = `${ident}${keyName}: ${joinedLines}${eol}`.split(eol)
-      for (let j = 0; j < splitLines.length; j += 1) {
-        if (j !== 0) result += eol
-
-        const line = splitLines[j]
-        if (/^\s*"stack"/.test(line)) {
-          const matches = /^(\s*"stack":)\s*(".*"),?$/.exec(line)
-          /* istanbul ignore else */
-          if (matches && matches.length === 3) {
-            const indentSize = /^\s*/.exec(line)[0].length + 4
-            const indentation = ' '.repeat(indentSize)
-            const stackMessage = matches[2]
-            result += matches[1] + eol + indentation + JSON.parse(stackMessage).replace(/\n/g, eol + indentation)
-          }
-        } else {
-          result += line
-        }
+  // Split object keys into two categories: error and non-error
+  const { plain, errors } = Object.entries(input).reduce(({ plain, errors }, [k, v]) => {
+    if (keysToIgnore.includes(k) === false) {
+      // Pre-apply custom prettifiers, because all 3 cases below will need this
+      const pretty = typeof customPrettifiers[k] === 'function'
+        ? customPrettifiers[k](v, k, input)
+        : v
+      if (errorLikeKeys.includes(k)) {
+        errors[k] = pretty
+      } else {
+        plain[k] = pretty
       }
-    } else {
-      result += `${ident}${keyName}: ${joinedLines}${eol}`
     }
+    return { plain, errors }
+  }, { plain: {}, errors: {} })
+
+  if (singleLine) {
+    // Stringify the entire object as a single JSON line
+    if (Object.keys(plain).length > 0) {
+      result += stringifySafe(plain)
+    }
+    result += eol
+  } else {
+    // Put each object entry on its own line
+    Object.entries(plain).forEach(([keyName, keyValue]) => {
+      // custom prettifiers are already applied above, so we can skip it now
+      const lines = typeof customPrettifiers[keyName] === 'function'
+        ? keyValue
+        : stringifySafe(keyValue, null, 2)
+
+      if (lines === undefined) return
+
+      const joinedLines = joinLinesWithIndentation({ input: lines, ident, eol })
+      result += `${ident}${keyName}: ${joinedLines}${eol}`
+    })
   }
+
+  // Errors
+  Object.entries(errors).forEach(([keyName, keyValue]) => {
+    // custom prettifiers are already applied above, so we can skip it now
+    const lines = typeof customPrettifiers[keyName] === 'function'
+      ? keyValue
+      : stringifySafe(keyValue, null, 2)
+
+    if (lines === undefined) return
+
+    result += prettifyError({ keyName, lines, eol, ident })
+  })
 
   return result
 }
@@ -386,4 +398,39 @@ function prettifyTime ({ log, timestampKey = TIMESTAMP_KEY, translateFormat = un
   }
 
   return `[${time}]`
+}
+
+/**
+ * Prettifies an error string into a multi-line format.
+ * @param {object} input
+ * @param {string} input.keyName The key assigned to this error in the log object
+ * @param {string} input.lines The STRINGIFIED error. If the error field has a
+ *  custom prettifier, that should be pre-applied as well
+ * @param {string} input.ident The indentation sequence to use
+ * @param {string} input.eol The EOL sequence to use
+ */
+function prettifyError ({ keyName, lines, eol, ident }) {
+  let result = ''
+  const joinedLines = joinLinesWithIndentation({ input: lines, ident, eol })
+  const splitLines = `${ident}${keyName}: ${joinedLines}${eol}`.split(eol)
+
+  for (let j = 0; j < splitLines.length; j += 1) {
+    if (j !== 0) result += eol
+
+    const line = splitLines[j]
+    if (/^\s*"stack"/.test(line)) {
+      const matches = /^(\s*"stack":)\s*(".*"),?$/.exec(line)
+      /* istanbul ignore else */
+      if (matches && matches.length === 3) {
+        const indentSize = /^\s*/.exec(line)[0].length + 4
+        const indentation = ' '.repeat(indentSize)
+        const stackMessage = matches[2]
+        result += matches[1] + eol + indentation + JSON.parse(stackMessage).replace(/\n/g, eol + indentation)
+      }
+    } else {
+      result += line
+    }
+  }
+
+  return result
 }

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -697,18 +697,38 @@ test('basic prettifier tests', (t) => {
     log.info({ key: 'value' }, 'hello world')
   })
 
-  t.test('multiline: false', (t) => {
+  t.test('Prints extra objects on one line with singleLine=true', (t) => {
     t.plan(1)
-    const pretty = prettyFactory({ multiline: false, colorize: true })
+    const pretty = prettyFactory({
+      singleLine: true,
+      colorize: false,
+      customPrettifiers: {
+        upper: val => val.toUpperCase(),
+        undef: () => undefined
+      }
+    })
     const log = pino({}, new Writable({
       write (chunk, enc, cb) {
         const formatted = pretty(chunk.toString())
-        t.is(formatted, `[${epoch}] \u001B[32mINFO \u001B[39m (${pid} on ${hostname}): \u001B[36m{ b: { c: 'd' } }\u001B[39m \x1B[90m{ extra: { foo: 'bar', number: 42 } }\x1B[39m\n`)
+        t.is(formatted, `[${epoch}] INFO (${pid} on ${hostname}): message {"extra":{"foo":"bar","number":42},"upper":"FOOBAR"}\n`)
 
         cb()
       }
     }))
-    log.info({ msg: { b: { c: 'd' } }, extra: { foo: 'bar', number: 42 } })
+    log.info({ msg: 'message', extra: { foo: 'bar', number: 42 }, upper: 'foobar', undef: 'this will not show up' })
+  })
+
+  t.test('Does not print empty object with singleLine=true', (t) => {
+    t.plan(1)
+    const pretty = prettyFactory({ singleLine: true, colorize: false })
+    const log = pino({}, new Writable({
+      write (chunk, enc, cb) {
+        const formatted = pretty(chunk.toString())
+        t.is(formatted, `[${epoch}] INFO (${pid} on ${hostname}): message \n`)
+        cb()
+      }
+    }))
+    log.info({ msg: 'message' })
   })
 
   t.end()

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -697,5 +697,19 @@ test('basic prettifier tests', (t) => {
     log.info({ key: 'value' }, 'hello world')
   })
 
+  t.test('multiline: false', (t) => {
+    t.plan(1)
+    const pretty = prettyFactory({ multiline: false, colorize: true })
+    const log = pino({}, new Writable({
+      write (chunk, enc, cb) {
+        const formatted = pretty(chunk.toString())
+        t.is(formatted, `[${epoch}] \u001B[32mINFO \u001B[39m (${pid} on ${hostname}): \u001B[36m{ b: { c: 'd' } }\u001B[39m \x1B[90m{ extra: { foo: 'bar', number: 42 } }\x1B[39m\n`)
+
+        cb()
+      }
+    }))
+    log.info({ msg: { b: { c: 'd' } }, extra: { foo: 'bar', number: 42 } })
+  })
+
   t.end()
 })

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -113,5 +113,25 @@ test('cli', (t) => {
     t.tearDown(() => child.kill())
   })
 
+  t.test('multiline: false', (t) => {
+    t.plan(1)
+
+    const logLineWithExtra = JSON.stringify(Object.assign(JSON.parse(logLine), {
+      extra: {
+        foo: 'bar',
+        number: 42
+      }
+    }))
+
+    const env = { TERM: 'dumb' }
+    const child = spawn(process.argv[0], [bin, '--multiline', 'false'], { env })
+    child.on('error', t.threw)
+    child.stdout.on('data', (data) => {
+      t.is(data.toString(), `[${epoch}] INFO  (42 on foo): hello world { extra: { foo: 'bar', number: 42 } }\n`)
+    })
+    child.stdin.write(logLineWithExtra)
+    t.tearDown(() => child.kill())
+  })
+
   t.end()
 })

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -113,7 +113,7 @@ test('cli', (t) => {
     t.tearDown(() => child.kill())
   })
 
-  t.test('multiline: false', (t) => {
+  t.test('singleLine=true', (t) => {
     t.plan(1)
 
     const logLineWithExtra = JSON.stringify(Object.assign(JSON.parse(logLine), {
@@ -121,13 +121,13 @@ test('cli', (t) => {
         foo: 'bar',
         number: 42
       }
-    }))
+    })) + '\n'
 
     const env = { TERM: 'dumb' }
-    const child = spawn(process.argv[0], [bin, '--multiline', 'false'], { env })
+    const child = spawn(process.argv[0], [bin, '--singleLine'], { env })
     child.on('error', t.threw)
     child.stdout.on('data', (data) => {
-      t.is(data.toString(), `[${epoch}] INFO  (42 on foo): hello world { extra: { foo: 'bar', number: 42 } }\n`)
+      t.is(data.toString(), `[${epoch}] INFO (42 on foo): hello world {"extra":{"foo":"bar","number":42}}\n`)
     })
     child.stdin.write(logLineWithExtra)
     t.tearDown(() => child.kill())

--- a/test/lib/utils.internals.test.js
+++ b/test/lib/utils.internals.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const tap = require('tap')
+const stringifySafe = require('fast-safe-stringify')
 const { internals } = require('../../lib/utils')
 
 tap.test('#joinLinesWithIndentation', t => {
@@ -77,6 +78,19 @@ tap.test('#formatTime', t => {
   t.test('translates date string to SYS:<FORMAT>', async t => {
     const formattedTime = internals.formatTime(dateStr, 'SYS:d mmm yyyy H:MM')
     t.match(formattedTime, /\d{1} \w{3} \d{4} \d{1,2}:\d{2}/)
+  })
+
+  t.end()
+})
+
+tap.test('#prettifyError', t => {
+  t.test('prettifies error', t => {
+    const error = Error('Bad error!')
+    const lines = stringifySafe(error, Object.getOwnPropertyNames(error), 2)
+
+    const prettyError = internals.prettifyError({ keyName: 'errorKey', lines, ident: '    ', eol: '\n' })
+    t.match(prettyError, /\s*errorKey: {\n\s*"stack":[\s\S]*"message": "Bad error!"/)
+    t.end()
   })
 
   t.end()


### PR DESCRIPTION
This adds a `singleLine` config option. When enabled, all unrecognized non-error fields will be printed on the same line as the main log message, as a simple JSON string. Error messages are still printed like normal, on a new line.

The implementation for this is **very** rough. I wanted to get feedback on the design/behavior before I spent any time polishing the code. I also haven't updated any docs yet. The tests should provide all the examples/behavior definitions needed though.

This builds off of #125 and hopefully fixes #97.

Remaining work:

- [x] Clean up code/add comments
- [x] Add docs