### PR TITLE
Fix trailing space in singleLine mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,8 +132,8 @@ module.exports = function prettyFactory (options) {
       }
     }
 
-    if (line.length > 0) {
-      line += (singleLine ? ' ' : EOL)
+    if (line.length > 0 && !singleLine) {
+      line += EOL
     }
 
     if (log.type === 'Error' && log.stack) {
@@ -157,6 +157,11 @@ module.exports = function prettyFactory (options) {
         singleLine,
         colorizer
       })
+
+      // In single line mode, include a space only if prettified version isn't empty
+      if (singleLine && !/^\s$/.test(prettifiedObject)) {
+        line += ' '
+      }
       line += prettifiedObject
     }
 

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -724,7 +724,7 @@ test('basic prettifier tests', (t) => {
     const log = pino({}, new Writable({
       write (chunk, enc, cb) {
         const formatted = pretty(chunk.toString())
-        t.is(formatted, `[${epoch}] INFO (${pid} on ${hostname}): message \n`)
+        t.is(formatted, `[${epoch}] INFO (${pid} on ${hostname}): message\n`)
         cb()
       }
     }))


### PR DESCRIPTION
A bug in #158 left a trailing space on lines that had no extra log fields with singleLine=true. This commit fixes that, and updates a test accordingly.

I'm sorry I didn't notice this in my initial PR, considering I wrote a test that included the bug.