### PR TITLE
Fix broken circular reference handling when filtering

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const clone = require('rfdc')()
+const clone = require('rfdc')({ circles: true })
 const dateformat = require('dateformat')
 const stringifySafe = require('fast-safe-stringify')
 const defaultColorizer = require('./colors')()

--- a/test/lib/utils.public.test.js
+++ b/test/lib/utils.public.test.js
@@ -364,3 +364,25 @@ tap.test('#filterLog', t => {
 
   t.end()
 })
+
+tap.test('#filterLog with circular references', t => {
+  const { filterLog } = utils
+  const logData = {
+    level: 30,
+    time: 1522431328992,
+    data1: 'test'
+  }
+  logData.circular = logData
+
+  t.test('filterLog removes single entry', async t => {
+    const result = filterLog(logData, ['data1'])
+
+    t.same(result.circular.level, result.level)
+    t.same(result.circular.time, result.time)
+
+    delete result.circular
+    t.same(result, { level: 30, time: 1522431328992 })
+  })
+
+  t.end()
+})


### PR DESCRIPTION
I updated from 4.7.1 to 5.0.1 and I kept getting an error regarding `rfdc`. Eventually tracked it down to this library. It seems like it was introduced in https://github.com/pinojs/pino-pretty/pull/180

```
/home/blaenk/code/app/bot/node_modules/rfdc/index.js:39
    if (o instanceof Date) return new Date(o)
          ^
RangeError: Maximum call stack size exceeded
    at Function.[Symbol.hasInstance] (<anonymous>)
    at clone (/home/blaenk/code/app/bot/node_modules/rfdc/index.js:39:11)
    at clone (/home/blaenk/code/app/bot/node_modules/rfdc/index.js:58:17)
    at clone (/home/blaenk/code/app/bot/node_modules/rfdc/index.js:58:17)
    at cloneArray (/home/blaenk/code/app/bot/node_modules/rfdc/index.js:31:17)
    at clone (/home/blaenk/code/app/bot/node_modules/rfdc/index.js:40:34)
    at cloneArray (/home/blaenk/code/app/bot/node_modules/rfdc/index.js:31:17)
    at clone (/home/blaenk/code/app/bot/node_modules/rfdc/index.js:52:25)
    at clone (/home/blaenk/code/app/bot/node_modules/rfdc/index.js:58:17)
    at clone (/home/blaenk/code/app/bot/node_modules/rfdc/index.js:58:17)
```

It seems like the log is unconditionally "cloned" via rfdc when `ignore` is set in the options.

https://github.com/pinojs/pino-pretty/blob/357590425b1d0b23e4e92cbf985d5de0dae1c194/lib/utils.js#L474

By default, rfdc doesn't track circular references so naturally it gets stuck infinitely traversing the circular references.

It seems rfdc does have a feature to [track circular references](https://github.com/davidmarkclements/rfdc#circles-option) albeit at the cost of performance since it has the overhead of tracking the references. I think that's ok since pino-pretty is meant for development uses anyway (AFAIK), and we already handle circular references in other areas (stringifying https://github.com/pinojs/pino-pretty/pull/50).

I do know that this didn't used to be a problem in 4.7.1. I also know regular `console.log()` is able to handle this of course (it'll simply print something like `<ref *1>`).

I'm not very familiar with tape and this was already a bit of an unexpected time sink, so please feel free to directly push any further commits to this branch and take over.