### PR TITLE
Permit non-standard time with --translateTime set

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -60,7 +60,13 @@ function formatTime (epoch, translateTime = false) {
     return epoch
   }
 
-  const instant = new Date(epoch)
+  const instant = createDate(epoch)
+
+  // If the Date is invalid, do not attempt to format
+  if (!isValidDate(instant)) {
+    return epoch
+  }
+
   if (translateTime === true) {
     return dateformat(instant, 'UTC:' + DATE_FORMAT)
   }
@@ -79,6 +85,34 @@ function formatTime (epoch, translateTime = false) {
   }
 
   return dateformat(instant, `UTC:${translateTime}`)
+}
+
+/**
+ * Replacement for the Date() constuctor. The argument may be any argument
+ * that is valid for the Date constuctor, or an epoch provided as a string.
+ *
+ * @epoch {string|number} - Argument for the date constructor.
+ *
+ * @returns {Date} date
+ */
+function createDate (epoch) {
+  // If epoch is already a valid argument, return the valid Date
+  let date = new Date(epoch)
+  if (isValidDate(date)) {
+    return date
+  }
+
+  // Convert to a number to permit epoch as a string
+  date = new Date(+epoch)
+  return date
+}
+
+/**
+ * Returns true if the argument is a Date object and not 'Invalid Date'
+ * @param {Date} date
+ */
+function isValidDate (date) {
+  return date instanceof Date && !Number.isNaN(date.getTime())
 }
 
 function isObject (input) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -30,7 +30,9 @@ module.exports.internals = {
   formatTime,
   joinLinesWithIndentation,
   prettifyError,
-  deleteLogProperty
+  deleteLogProperty,
+  createDate,
+  isValidDate
 }
 
 /**
@@ -88,12 +90,13 @@ function formatTime (epoch, translateTime = false) {
 }
 
 /**
- * Replacement for the Date() constuctor. The argument may be any argument
- * that is valid for the Date constuctor, or an epoch provided as a string.
+ * Constructs a JS Date from a number or string. Accepts any single number
+ * or single string argument that is valid for the Date() constructor,
+ * or an epoch as a string.
  *
- * @epoch {string|number} - Argument for the date constructor.
+ * @param {string|number} epoch The representation of the Date.
  *
- * @returns {Date} date
+ * @returns {Date} The constructed Date.
  */
 function createDate (epoch) {
   // If epoch is already a valid argument, return the valid Date
@@ -108,8 +111,11 @@ function createDate (epoch) {
 }
 
 /**
- * Returns true if the argument is a Date object and not 'Invalid Date'
- * @param {Date} date
+ * Checks if the argument is a JS Date and not 'Invalid Date'.
+ *
+ * @param {Date} date The date to check.
+ *
+ * @returns {boolean} true if the argument is a JS Date and not 'Invalid Date'.
  */
 function isValidDate (date) {
   return date instanceof Date && !Number.isNaN(date.getTime())

--- a/test/lib/utils.internals.test.js
+++ b/test/lib/utils.internals.test.js
@@ -84,6 +84,40 @@ tap.test('#formatTime', t => {
   t.end()
 })
 
+tap.test('#createDate', t => {
+  const wanted = 1624450038567
+
+  t.test('accepts arguments the Date constructor would accept', async t => {
+    t.plan(2)
+    t.same(internals.createDate(1624450038567).getTime(), wanted)
+    t.same(internals.createDate('2021-06-23T12:07:18.567Z').getTime(), wanted)
+  })
+
+  t.test('accepts epoch as a string', async t => {
+    // If Date() accepts this argument, the createDate function is not needed
+    // and can be replaced with Date()
+    t.plan(2)
+    t.notSame(new Date('16244500385-67').getTime(), wanted)
+    t.same(internals.createDate('1624450038567').getTime(), wanted)
+  })
+
+  t.end()
+})
+
+tap.test('#isValidDate', t => {
+  t.test('returns true for valid dates', async t => {
+    t.same(internals.isValidDate(new Date()), true)
+  })
+
+  t.test('returns false for non-dates and invalid dates', async t => {
+    t.plan(2)
+    t.same(internals.isValidDate('20210621'), false)
+    t.same(internals.isValidDate(new Date('2021-41-99')), false)
+  })
+
+  t.end()
+})
+
 tap.test('#prettifyError', t => {
   t.test('prettifies error', t => {
     const error = Error('Bad error!')

--- a/test/lib/utils.public.test.js
+++ b/test/lib/utils.public.test.js
@@ -339,6 +339,26 @@ tap.test('prettifyTime', t => {
     t.equal(str, '[0]')
   })
 
+  t.test('works with epoch as a number or string', (t) => {
+    t.plan(3)
+    const epoch = 1522431328992
+    const asNumber = prettifyTime({
+      log: { time: epoch, msg: 'foo' },
+      translateFormat: true
+    })
+    const asString = prettifyTime({
+      log: { time: `${epoch}`, msg: 'foo' },
+      translateFormat: true
+    })
+    const invalid = prettifyTime({
+      log: { time: '2 days ago', msg: 'foo' },
+      translateFormat: true
+    })
+    t.same(asString, '[2018-03-30 17:35:28.992 +0000]')
+    t.same(asNumber, '[2018-03-30 17:35:28.992 +0000]')
+    t.same(invalid, '[2 days ago]')
+  })
+
   t.end()
 })
 


### PR DESCRIPTION
Fixes #198
* When the `time` value cannot be parsed to a Date, leave it unformatted
* Allow epoch as the `time` value to be a number or string

Example:
```sh
(
  echo '{"time":"1623170292956","msg":"one"}'
  echo '{"time":1623170292956,"msg":"two"}'
  echo '{"time":"2 days ago","msg":"three"}'
) | npx pino-pretty --translateTime
```

Old behaviour: 
```
```
(emits nothing)

New behaviour:
```
[2021-06-08 16:38:12.956 +0000]: one
[2021-06-08 16:38:12.956 +0000]: two
[2 days ago]: three
```