### PR TITLE
Added type declaration for custom prettifiers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -99,6 +99,27 @@ interface PrettyOptions_ {
    * @example "time,hostname"
    */
   ignore?: string;
+  /**
+   * Provides the ability to add a custom prettify function for specific log properties.
+   * `customPrettifiers` is an object, where keys are log properties that will be prettified
+   * and value is the prettify function itself.
+   * For example, if a log line contains a query property, you can specify a prettifier for it:
+   * @default {}
+   *
+   * @example
+   * ```typescript
+   * {
+   *   customPrettifiers: {
+   *     query: prettifyQuery
+   *   }
+   * }
+   * //...
+   * const prettifyQuery = value => {
+   *  // do some prettify magic
+   * }
+   * ```
+   */
+  customPrettifiers?: Record<string, PinoPretty.Prettifier>;
 }
 
 declare namespace PinoPretty {

--- a/test/types/pino-pretty.test-d.ts
+++ b/test/types/pino-pretty.test-d.ts
@@ -24,6 +24,11 @@ const options: PinoPretty.PrettyOptions = {
   translateTime: "UTC:h:MM:ss TT Z",
   search: "foo == `bar`",
   singleLine: false,
+  customPrettifiers: {
+    key: (value) => {
+      return value.toString().toUpperCase();
+    }
+  }
 };
 
 const options2: PrettyOptions = {
@@ -42,6 +47,11 @@ const options2: PrettyOptions = {
   translateTime: "UTC:h:MM:ss TT Z",
   search: "foo == `bar`",
   singleLine: false,
+  customPrettifiers: {
+    key: (value) => {
+      return value.toString().toUpperCase();
+    }
+  }
 };
 
 const pretty = prettyFactory(options);


### PR DESCRIPTION
Hello,

This PR adds `customPrettifiers` to type declarations because it was missing. Description and example were taken from the original documentation ([ref](https://github.com/pinojs/pino-pretty#options)).