### PR TITLE
Use pino-abstract-transport

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -3,18 +3,19 @@
 const fs = require('fs')
 const args = require('args')
 const path = require('path')
+const pump = require('pump')
+const bourne = require('@hapi/bourne')
+const JoyCon = require('joycon')
+const stripJsonComments = require('strip-json-comments')
+
 const build = require('./')
 const CONSTANTS = require('./lib/constants')
-const pump = require('pump')
 const { isObject } = require('./lib/utils')
 
-const bourne = require('@hapi/bourne')
-const stripJsonComments = require('strip-json-comments')
 const parseJSON = input => {
   return bourne.parse(stripJsonComments(input), { protoAction: 'remove' })
 }
 
-const JoyCon = require('joycon')
 const joycon = new JoyCon({
   parseJSON,
   files: [

--- a/bin.js
+++ b/bin.js
@@ -3,11 +3,9 @@
 const fs = require('fs')
 const args = require('args')
 const path = require('path')
-const pump = require('pump')
-const split = require('split2')
-const { Transform } = require('readable-stream')
-const prettyFactory = require('./')
+const build = require('./')
 const CONSTANTS = require('./lib/constants')
+const pump = require('pump')
 const { isObject } = require('./lib/utils')
 
 const bourne = require('@hapi/bourne')
@@ -88,17 +86,9 @@ opts = Object.assign({}, config, opts)
 // set defaults
 opts.errorLikeObjectKeys = opts.errorLikeObjectKeys || 'err,error'
 opts.errorProps = opts.errorProps || ''
-const pretty = prettyFactory(opts)
-const prettyTransport = new Transform({
-  objectMode: true,
-  transform (chunk, enc, cb) {
-    const line = pretty(chunk.toString())
-    if (line === undefined) return cb()
-    cb(null, line)
-  }
-})
 
-pump(process.stdin, split(), prettyTransport, process.stdout)
+const res = build(opts)
+pump(process.stdin, res)
 
 // https://github.com/pinojs/pino/pull/358
 /* istanbul ignore next */

--- a/index.js
+++ b/index.js
@@ -5,8 +5,10 @@ const pump = require('pump')
 const { Transform } = require('readable-stream')
 const abstractTransport = require('pino-abstract-transport')
 const jmespath = require('jmespath')
-const colors = require('./lib/colors')
 const sonic = require('sonic-boom')
+const bourne = require('@hapi/bourne')
+
+const colors = require('./lib/colors')
 const { ERROR_LIKE_KEYS, MESSAGE_KEY, TIMESTAMP_KEY } = require('./lib/constants')
 const {
   isObject,
@@ -19,7 +21,6 @@ const {
   filterLog
 } = require('./lib/utils')
 
-const bourne = require('@hapi/bourne')
 const jsonParser = input => {
   try {
     return { value: bourne.parse(input, { protoAction: 'remove' }) }

--- a/index.js
+++ b/index.js
@@ -169,7 +169,7 @@ function prettyFactory (options) {
   }
 }
 
-function build (opts) {
+function build (opts = {}) {
   const pretty = prettyFactory(opts)
   return abstractTransport(function (source) {
     const stream = new Transform({

--- a/index.js
+++ b/index.js
@@ -1,8 +1,12 @@
 'use strict'
 
 const { options: coloretteOptions } = require('colorette')
+const pump = require('pump')
+const { Transform } = require('readable-stream')
+const abstractTransport = require('pino-abstract-transport')
 const jmespath = require('jmespath')
 const colors = require('./lib/colors')
+const sonic = require('sonic-boom')
 const { ERROR_LIKE_KEYS, MESSAGE_KEY, TIMESTAMP_KEY } = require('./lib/constants')
 const {
   isObject,
@@ -165,6 +169,41 @@ function prettyFactory (options) {
   }
 }
 
-prettyFactory.prettyFactory = prettyFactory
-prettyFactory.default = prettyFactory
-module.exports = prettyFactory
+function build (opts) {
+  const pretty = prettyFactory(opts)
+  return abstractTransport(function (source) {
+    const stream = new Transform({
+      objectMode: true,
+      autoDestroy: true,
+      transform (chunk, enc, cb) {
+        const line = pretty(chunk)
+        if (line === undefined) {
+          cb()
+          return
+        }
+
+        cb(null, line)
+      }
+    })
+
+    const destination = sonic({ dest: opts.destination || 1, sync: false })
+    /* istanbul ignore else */
+    if (destination.fd === 1) {
+      // We cannot close the output
+      destination.end = function () {
+        this.emit('close')
+      }
+    }
+
+    source.on('unknown', function (line) {
+      destination.write(line + '\n')
+    })
+
+    pump(source, stream, destination)
+    return stream
+  }, { parse: 'lines' })
+}
+
+module.exports = build
+module.exports.prettyFactory = prettyFactory
+module.exports.default = build

--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
     "fast-safe-stringify": "^2.0.7",
     "jmespath": "^0.15.0",
     "joycon": "^3.0.0",
+    "pino-abstract-transport": "^0.2.0",
     "pump": "^3.0.0",
     "readable-stream": "^3.6.0",
     "rfdc": "^1.3.0",
-    "split2": "^3.1.1",
     "strip-json-comments": "^3.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "pump": "^3.0.0",
     "readable-stream": "^3.6.0",
     "rfdc": "^1.3.0",
+    "sonic-boom": "^2.2.0",
     "strip-json-comments": "^3.1.1"
   },
   "devDependencies": {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -5,7 +5,8 @@ const os = require('os')
 const test = require('tap').test
 const pino = require('pino')
 const dateformat = require('dateformat')
-const _prettyFactory = require('../').prettyFactory
+const pinoPretty = require('..')
+const _prettyFactory = pinoPretty.prettyFactory
 
 function prettyFactory (opts) {
   if (!opts) {
@@ -726,6 +727,11 @@ test('basic prettifier tests', (t) => {
       }
     }))
     log.info({ msg: 'message' })
+  })
+
+  t.test('default options', (t) => {
+    t.plan(1)
+    t.doesNotThrow(pinoPretty)
   })
 
   t.end()

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -5,7 +5,7 @@ const os = require('os')
 const test = require('tap').test
 const pino = require('pino')
 const dateformat = require('dateformat')
-const _prettyFactory = require('../')
+const _prettyFactory = require('../').prettyFactory
 
 function prettyFactory (opts) {
   if (!opts) {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -114,6 +114,23 @@ test('cli', (t) => {
     t.teardown(() => child.kill())
   })
 
+  t.test('end stdin does not end the destination', (t) => {
+    t.plan(2)
+    const child = spawn(process.argv[0], [bin], { env })
+    child.on('error', t.threw)
+
+    child.stdout.on('data', (data) => {
+      t.equal(data.toString(), 'aaa\n')
+    })
+
+    child.stdin.end('aaa\n')
+    child.on('exit', function (code) {
+      t.equal(code, 0)
+    })
+
+    t.teardown(() => child.kill())
+  })
+
   ;['--timestampKey', '-a'].forEach((optionName) => {
     t.test(`uses specified timestamp key via ${optionName}`, (t) => {
       t.plan(1)

--- a/test/crlf.test.js
+++ b/test/crlf.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const test = require('tap').test
-const _prettyFactory = require('../')
+const _prettyFactory = require('../').prettyFactory
 
 function prettyFactory (opts) {
   if (!opts) {

--- a/test/error-objects.test.js
+++ b/test/error-objects.test.js
@@ -5,7 +5,7 @@ const os = require('os')
 const test = require('tap').test
 const pino = require('pino')
 const serializers = pino.stdSerializers
-const _prettyFactory = require('../')
+const _prettyFactory = require('../').prettyFactory
 
 function prettyFactory (opts) {
   if (!opts) {


### PR DESCRIPTION
This change makes this module compatible with the new transport system.

This is the first step for https://github.com/pinojs/pino/issues/1106.

It is a semver-major change and it will require a minor change in pino@6 and pino@7 to achieve compatibility. before we exported the `prettyFactory`, now we export the function to build a transport, which includes split2.