### PR TITLE
fix: dateformat migrated to esm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    outputs:
+      COVERALLS: ${{ steps.coveralls-trigger.outputs.COVERALLS_TRIGGER }}
     strategy:
       matrix:
         node-version: [10, 12, 14, 16]
@@ -39,6 +41,7 @@ jobs:
         run: npm run ci
 
       - name: Coveralls Parallel
+        id: coveralls-parallel
         uses: coverallsapp/github-action@1.1.3
         continue-on-error: true
         with:
@@ -46,10 +49,18 @@ jobs:
           parallel: true
           flag-name: run-${{ matrix.node-version }}-${{ matrix.os }}
 
+      - name: Should Trigger coverallsapp/github-action@master
+        id: coveralls-trigger
+        # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#steps-context
+        # when continue-on-error failed, outcome is failure and conclusion is success
+        if: steps.coveralls-parallel.conclusion == 'success' && steps.coveralls-parallel.outcome != 'success'
+        run: |
+          echo "::set-output name=COVERALLS_TRIGGER::failure"
+
   coverage:
     needs: build
     runs-on: ubuntu-latest
-    continue-on-error: true
+    if: needs.test.outputs.COVERALLS != 'failure'
     steps:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@1.1.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
 
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@1.1.3
+        continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel: true
@@ -48,6 +49,7 @@ jobs:
   coverage:
     needs: build
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@1.1.3

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "args": "^5.0.1",
     "colorette": "^2.0.0",
-    "dateformat": "~4.5.1",
+    "dateformat": "^4.6.3",
     "fast-safe-stringify": "^2.0.7",
     "joycon": "^3.0.0",
     "pino-abstract-transport": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "args": "^5.0.1",
     "colorette": "^2.0.0",
-    "dateformat": "^4.5.1",
+    "dateformat": "~4.5.1",
     "fast-safe-stringify": "^2.0.7",
     "joycon": "^3.0.0",
     "pino-abstract-transport": "^0.3.0",


### PR DESCRIPTION
As `dateformat` moved from `CJS` to `ESM`.
Change the version to `~` flag to prevent further impact.

Related to https://github.com/pinojs/pino/pull/1137