### PR TITLE
Switch to @matteo.collina/dateformat

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const clone = require('rfdc')({ circles: true })
-const dateformat = require('dateformat')
+const dateformat = require('@matteo.collina/dateformat')
 const stringifySafe = require('fast-safe-stringify')
 const defaultColorizer = require('./colors')()
 const {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "args": "^5.0.1",
     "colorette": "^2.0.0",
-    "dateformat": "^4.5.1",
+    "@matteo.collina/dateformat": "^5.0.1",
     "fast-safe-stringify": "^2.0.7",
     "joycon": "^3.0.0",
     "pino-abstract-transport": "^0.3.0",

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -4,7 +4,7 @@ const { Writable } = require('readable-stream')
 const os = require('os')
 const test = require('tap').test
 const pino = require('pino')
-const dateformat = require('dateformat')
+const dateformat = require('@matteo.collina/dateformat')
 const pinoPretty = require('..')
 const _prettyFactory = pinoPretty.prettyFactory
 


### PR DESCRIPTION
The dateformat maintainers decided that the v5.0.0 release would be
ESM-only. Give the current stance of keeping the pino ecosystem to CJS
for the time being, I do not think it is a safe long-term to depend
on this library. Therefore I forked it.