### PR TITLE
style(test/types): make implicitly inserted semicolon explicit

### DIFF
--- a/test/types/pino-pretty.test-d.ts
+++ b/test/types/pino-pretty.test-d.ts
@@ -53,7 +53,7 @@ const options2: PrettyOptions = {
 };
 
 const pretty = prettyFactory(options);
-expectType<Prettifier>(pretty)
+expectType<Prettifier>(pretty);
 
 expectType<Prettifier>(PinoPrettyNamed(options));
 expectType<Prettifier>(PinoPrettyDefault(options));


### PR DESCRIPTION
All of the other statements in the file have explicit semicolons; updated to be consistent.