### PR TITLE
Add ability to format time and level with user-defined prettifiers

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -238,7 +238,8 @@ const prettifyQuery = value => {
 }
 ```
 
-Additionally, `customPrettifiers` can be used to format the time and level outputs:
+Additionally, `customPrettifiers` can be used to format the time and level
+outputs:
 ```js
 {
   customPrettifiers: {
@@ -252,18 +253,6 @@ Additionally, `customPrettifiers` can be used to format the time and level outpu
     level: logLevel => `LEVEL: ${logLevel}`
   }
 }
-```
-
-Note that prettifiers do not include any coloring, if the stock coloring on `level` is desired, it can be accomplished using the following:
-```js
-const { colorizerFactory } = require('pino-pretty')
-const levelColorize = colorizerFactory(true)
-const levelPrettifier = logLevel => `LEVEL: ${levelColorize(logLevel)}`
-//...
-{
-  customPrettifiers: { level: levelPrettifier }
-}
-```
 
 `messageFormat` option allows you to customize the message output. A template `string` like this can define the format:
 ```js

--- a/Readme.md
+++ b/Readme.md
@@ -238,21 +238,20 @@ const prettifyQuery = value => {
 }
 ```
 
-You can also use `customPrettifiers` to format the time and level outputs:
+Additionally, `customPrettifiers` can be used to format the time and level outputs:
 ```js
 {
   customPrettifiers: {
-    // the argument for this function will be the same
-    // string that's at the start of the log-line by default
+    // The argument for this function will be the same
+    // string that's at the start of the log-line by default:
     time: timestamp => `🕰 ${timestamp}`,
-    // the argument for the level-prettifier may vary depending
-    // on if you're using the levelKey option or not.
-    // by default this will be the same numerics as the Pino default
+    
+    // The argument for the level-prettifier may vary depending
+    // on if the levelKey option is used or not.
+    // By default this will be the same numerics as the Pino default:
     level: logLevel => `LEVEL: ${logLevel}`
   }
 }
-```
-
 `messageFormat` option allows you to customize the message output. A template `string` like this can define the format:
 ```js
 {

--- a/Readme.md
+++ b/Readme.md
@@ -254,6 +254,17 @@ outputs:
   }
 }
 
+Note that prettifiers do not include any coloring, if the stock coloring on
+`level` is desired, it can be accomplished using the following:
+```js
+const { colorizerFactory } = require('pino-pretty')
+const levelColorize = colorizerFactory(true)
+const levelPrettifier = logLevel => `LEVEL: ${levelColorize(logLevel)}`
+//...
+{
+  customPrettifiers: { level: levelPrettifier }
+}
+
 `messageFormat` option allows you to customize the message output. A template `string` like this can define the format:
 ```js
 {

--- a/Readme.md
+++ b/Readme.md
@@ -256,7 +256,8 @@ Additionally, `customPrettifiers` can be used to format the time and level outpu
 
 Note that prettifiers do not include any coloring, if the stock coloring on `level` is desired, it can be accomplished using the following:
 ```js
-const levelColorize = require('pino-pretty/lib/colors.js')(true)
+const { colorizerFactory } = require('pino-pretty')
+const levelColorize = colorizerFactory(true)
 const levelPrettifier = logLevel => `LEVEL: ${levelColorize(logLevel)}`
 //...
 {

--- a/Readme.md
+++ b/Readme.md
@@ -245,13 +245,25 @@ Additionally, `customPrettifiers` can be used to format the time and level outpu
     // The argument for this function will be the same
     // string that's at the start of the log-line by default:
     time: timestamp => `🕰 ${timestamp}`,
-    
+
     // The argument for the level-prettifier may vary depending
     // on if the levelKey option is used or not.
     // By default this will be the same numerics as the Pino default:
     level: logLevel => `LEVEL: ${logLevel}`
   }
 }
+```
+
+Note that prettifiers do not include any coloring, if the stock coloring on `level` is desired, it can be accomplished using the following:
+```js
+const levelColorize = require('pino-pretty/lib/colors.js')(true)
+const levelPrettifier = logLevel => `LEVEL: ${levelColorize(logLevel)}`
+
+{
+  customPrettifiers: { level: levelPrettifier }
+}
+```
+
 `messageFormat` option allows you to customize the message output. A template `string` like this can define the format:
 ```js
 {

--- a/Readme.md
+++ b/Readme.md
@@ -258,7 +258,7 @@ Note that prettifiers do not include any coloring, if the stock coloring on `lev
 ```js
 const levelColorize = require('pino-pretty/lib/colors.js')(true)
 const levelPrettifier = logLevel => `LEVEL: ${levelColorize(logLevel)}`
-
+//...
 {
   customPrettifiers: { level: levelPrettifier }
 }

--- a/Readme.md
+++ b/Readme.md
@@ -238,6 +238,21 @@ const prettifyQuery = value => {
 }
 ```
 
+You can also use `customPrettifiers` to format the time and level outputs:
+```js
+{
+  customPrettifiers: {
+    // the argument for this function will be the same
+    // string that's at the start of the log-line by default
+    time: timestamp => `🕰 ${timestamp}`,
+    // the argument for the level-prettifier may vary depending
+    // on if you're using the levelKey option or not.
+    // by default this will be the same numerics as the Pino default
+    level: logLevel => `LEVEL: ${logLevel}`
+  }
+}
+```
+
 `messageFormat` option allows you to customize the message output. A template `string` like this can define the format:
 ```js
 {

--- a/index.js
+++ b/index.js
@@ -214,4 +214,5 @@ function build (opts = {}) {
 
 module.exports = build
 module.exports.prettyFactory = prettyFactory
+module.exports.colorizerFactory = colors
 module.exports.default = build

--- a/index.js
+++ b/index.js
@@ -90,9 +90,9 @@ function prettyFactory (options) {
       log = filterLog(log, ignoreKeys)
     }
 
-    const prettifiedLevel = prettifyLevel({ log, colorizer, levelKey })
+    const prettifiedLevel = prettifyLevel({ log, colorizer, levelKey, prettifier: customPrettifiers.level })
     const prettifiedMetadata = prettifyMetadata({ log })
-    const prettifiedTime = prettifyTime({ log, translateFormat: opts.translateTime, timestampKey })
+    const prettifiedTime = prettifyTime({ log, translateFormat: opts.translateTime, timestampKey, prettifier: customPrettifiers.time })
 
     let line = ''
     if (opts.levelFirst && prettifiedLevel) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -425,7 +425,7 @@ function prettifyObject ({
  * timestamp will be prettified into a string at UTC using the default
  * `DATE_FORMAT`. If a string, then `translateFormat` will be used as the format
  * string to determine the output; see the `formatTime` function for details.
- * @param {function} input.colorizer A user-supplied formatter for altering output
+ * @param {function} [input.prettifier] A user-supplied formatter for altering output.
  *
  * @returns {undefined|string} If a timestamp property cannot be found then
  * `undefined` is returned. Otherwise, the prettified time is returned as a

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -218,6 +218,7 @@ function prettifyErrorLog ({
  * @param {function} [input.colorizer] A colorizer function that accepts a level
  * value and returns a colorized string. Default: a no-op colorizer.
  * @param {string} [levelKey='level'] The key to find the level under.
+ * @param {function} input.colorizer A user-supplied formatter to be called instead of colorizer
  *
  * @returns {undefined|string} If `log` does not have a `level` property then
  * `undefined` will be returned. Otherwise, a string from the specified
@@ -424,6 +425,7 @@ function prettifyObject ({
  * timestamp will be prettified into a string at UTC using the default
  * `DATE_FORMAT`. If a string, then `translateFormat` will be used as the format
  * string to determine the output; see the `formatTime` function for details.
+ * @param {function} input.colorizer A user-supplied formatter for altering output
  *
  * @returns {undefined|string} If a timestamp property cannot be found then
  * `undefined` is returned. Otherwise, the prettified time is returned as a

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -218,7 +218,7 @@ function prettifyErrorLog ({
  * @param {function} [input.colorizer] A colorizer function that accepts a level
  * value and returns a colorized string. Default: a no-op colorizer.
  * @param {string} [levelKey='level'] The key to find the level under.
- * @param {function} input.colorizer A user-supplied formatter to be called instead of colorizer
+ * @param {function} [input.prettifier] A user-supplied formatter to be called instead of colorizer.
  *
  * @returns {undefined|string} If `log` does not have a `level` property then
  * `undefined` will be returned. Otherwise, a string from the specified

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -223,9 +223,10 @@ function prettifyErrorLog ({
  * `undefined` will be returned. Otherwise, a string from the specified
  * `colorizer` is returned.
  */
-function prettifyLevel ({ log, colorizer = defaultColorizer, levelKey = LEVEL_KEY }) {
+function prettifyLevel ({ log, colorizer = defaultColorizer, levelKey = LEVEL_KEY, prettifier }) {
   if (levelKey in log === false) return undefined
-  return colorizer(log[levelKey])
+  const output = log[levelKey]
+  return prettifier ? prettifier(output) : colorizer(output)
 }
 
 /**
@@ -428,7 +429,7 @@ function prettifyObject ({
  * `undefined` is returned. Otherwise, the prettified time is returned as a
  * string.
  */
-function prettifyTime ({ log, timestampKey = TIMESTAMP_KEY, translateFormat = undefined }) {
+function prettifyTime ({ log, timestampKey = TIMESTAMP_KEY, translateFormat = undefined, prettifier }) {
   let time = null
 
   if (timestampKey in log) {
@@ -438,11 +439,9 @@ function prettifyTime ({ log, timestampKey = TIMESTAMP_KEY, translateFormat = un
   }
 
   if (time === null) return undefined
-  if (translateFormat) {
-    return '[' + formatTime(time, translateFormat) + ']'
-  }
+  const output = translateFormat ? formatTime(time, translateFormat) : time
 
-  return `[${time}]`
+  return prettifier ? prettifier(output) : `[${output}]`
 }
 
 /**

--- a/test/lib/colors.test.js
+++ b/test/lib/colors.test.js
@@ -1,9 +1,10 @@
 'use strict'
 
 const { test } = require('tap')
-const getColorizer = require('../../lib/colors')
+const getColorizerPrivate = require('../../lib/colors')
+const { colorizerFactory: getColorizerPublic } = require('../../index')
 
-test('returns default colorizer', async t => {
+const testDefaultColorizer = getColorizer => async t => {
   const colorizer = getColorizer()
   let colorized = colorizer(10)
   t.equal(colorized, 'TRACE')
@@ -37,9 +38,9 @@ test('returns default colorizer', async t => {
 
   colorized = colorizer.greyMessage('foo')
   t.equal(colorized, 'foo')
-})
+}
 
-test('returns colorizing colorizer', async t => {
+const testColoringColorizer = getColorizer => async t => {
   const colorizer = getColorizer(true)
   let colorized = colorizer(10)
   t.equal(colorized, '\u001B[90mTRACE\u001B[39m')
@@ -73,4 +74,9 @@ test('returns colorizing colorizer', async t => {
 
   colorized = colorizer.greyMessage('foo')
   t.equal(colorized, '\u001B[90mfoo\u001B[39m')
-})
+}
+
+test('returns default colorizer - private export', testDefaultColorizer(getColorizerPrivate))
+test('returns default colorizer - public export', testDefaultColorizer(getColorizerPublic))
+test('returns colorizing colorizer - private export', testColoringColorizer(getColorizerPrivate))
+test('returns colorizing colorizer - public export', testColoringColorizer(getColorizerPublic))


### PR DESCRIPTION
This would close issues like #185, and put more formatting capabilities into userland.

If another option-key besides `customPrettifiers` should be used I'm happy to switch. I think the docs are a bit open to interpretation even though I see this option is only being used to prettify object-formatting right now.