### PR TITLE
chore: Added example to provide pino core options.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -153,6 +153,21 @@ logger.info('hi')
 
 See the [Options](#options) section for all possible options.
 
+If you are using pino-pretty as stream and you need to provide options to pino, pass them as first argument and pino-pretty as second argument:
+
+```js
+const pino = require('pino')
+const pretty = require('pino-pretty')
+const stream = pretty({
+  prettyPrint: { colorize: true }
+})
+const logger = pino({ level: 'info' }, stream)
+
+// Nothing is printed
+logger.debug('hi')
+```
+
+
 ### Handling non-serializable options
 
 Using the new [pino v7+

--- a/Readme.md
+++ b/Readme.md
@@ -153,7 +153,8 @@ logger.info('hi')
 
 See the [Options](#options) section for all possible options.
 
-If you are using pino-pretty as stream and you need to provide options to pino, pass them as first argument and pino-pretty as second argument:
+If you are using `pino-pretty` as a stream and you need to provide options to `pino`,
+pass the options as the first argument and `pino-pretty` as second argument:
 
 ```js
 const pino = require('pino')


### PR DESCRIPTION
Hello!
As stated in the title, this add an example on how to use pino-pretty as stream while still passing pino options.