### PR TITLE
append missing eol before appending prettified error object when singleLine=true

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,6 +146,7 @@ function prettyFactory (options) {
         ident: IDENT,
         eol: EOL
       })
+      if (singleLine) line += EOL
       line += prettifiedErrorLog
     } else if (!hideObject) {
       const skipKeys = [messageKey, levelKey, timestampKey].filter(key => typeof log[key] === 'string' || typeof log[key] === 'number')


### PR DESCRIPTION
Here's how the output currently looks:

```
[1637396183072] ERROR: something bad happened    Error: something bad happened
        at Object.<anonymous> (/tmp/pino-lab/fiddle.js:16:9)
```

Here's what we expect:

```
[1637396183072] ERROR: something bad happened
    Error: something bad happened
        at Object.<anonymous> (/tmp/pino-lab/fiddle.js:16:9)
```