### PR TITLE
Allow loading common js config files by default

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -19,6 +19,7 @@ const parseJSON = input => {
 const joycon = new JoyCon({
   parseJSON,
   files: [
+    'pino-pretty.config.cjs',
     'pino-pretty.config.js',
     '.pino-prettyrc',
     '.pino-prettyrc.json'

--- a/bin.js
+++ b/bin.js
@@ -26,10 +26,6 @@ const joycon = new JoyCon({
   ],
   stopDir: path.dirname(process.cwd())
 })
-joycon.addLoader({
-  test: /\.[^.]*rc$/,
-  loadSync: (path) => parseJSON(fs.readFileSync(path, 'utf-8'))
-})
 
 args
   .option(['c', 'colorize'], 'Force adding color sequences to the output')

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "colorette": "^2.0.7",
     "dateformat": "^4.6.3",
     "fast-safe-stringify": "^2.0.7",
-    "joycon": "^3.0.0",
+    "joycon": "^3.1.1",
     "pino-abstract-transport": "^0.5.0",
     "pump": "^3.0.0",
     "readable-stream": "^3.6.0",

--- a/test/cli-rc.test.js
+++ b/test/cli-rc.test.js
@@ -35,6 +35,29 @@ test('cli', (t) => {
     })
   })
 
+  t.test('loads and applies default config file: pino-pretty.config.cjs', (t) => {
+    t.plan(1)
+    // Set translateTime: true on run configuration
+    const configFile = path.join(tmpDir, 'pino-pretty.config.cjs')
+    fs.writeFileSync(configFile, 'module.exports = { translateTime: true }')
+    // Tell the loader to expect ESM modules
+    const packageJsonFile = path.join(tmpDir, 'package.json')
+    fs.writeFileSync(packageJsonFile, JSON.stringify({ type: 'module' }, null, 4))
+    const env = { TERM: 'dumb' }
+    const child = spawn(process.argv[0], [bin], { env, cwd: tmpDir })
+    // Validate that the time has been translated
+    child.on('error', t.threw)
+    child.stdout.on('data', (data) => {
+      t.equal(data.toString(), '[2018-03-30 17:35:28.992 +0000] INFO (42 on foo): hello world\n')
+    })
+    child.stdin.write(logLine)
+    t.teardown(() => {
+      fs.unlinkSync(configFile)
+      fs.unlinkSync(packageJsonFile)
+      child.kill()
+    })
+  })
+
   t.test('loads and applies default config file: .pino-prettyrc', (t) => {
     t.plan(1)
     // Set translateTime: true on run configuration


### PR DESCRIPTION
If your project is ESM by default, then you need to make common js files have the cjs extension to load. This just adds that to the list of files to try loading.

I have also removed the custom joycon loader, because it always tries to parse JSON now.