### PR TITLE
Line simplification for development

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,6 +1,5 @@
 ts: false
 jsx: false
 flow: false
-jobs: 1
 files:
   - 'test/**/*.test.js'

--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@
 [![Coverage Status](https://img.shields.io/coveralls/github/pinojs/pino-pretty)](https://coveralls.io/github/pinojs/pino-pretty?branch=master)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://standardjs.com/)
 
-This module provides a basic [ndjson](http://ndjson.org/) formatter. If an
+This module provides a basic [ndjson](http://ndjson.org/) formatter to be used in __development__. If an
 incoming line looks like it could be a log line from an ndjson logger, in
 particular the [Pino](https://getpino.io/) logging library, then it will apply
 extra formatting by considering things like the log level and timestamp.
@@ -20,7 +20,7 @@ A standard Pino log line like:
 Will format to:
 
 ```
-[1522431328992] INFO (42 on foo): hello world
+[17:35:28.992] INFO (42): hello world
 ```
 
 If you landed on this page due to the deprecation of the `prettyPrint` option
@@ -84,13 +84,15 @@ node app.js | pino-pretty
   date and time string. This flag also can set the format string to apply when
   translating the date to a human-readable format. For a list of available pattern
   letters, see the [`dateformat` documentation](https://www.npmjs.com/package/dateformat).
-  - The default format is `yyyy-mm-dd HH:MM:ss.l o` in UTC.
+  - The default format is `HH:MM:ss.l` in the local timezone.
+  - Require a `UTC:` prefix to translate time to UTC, e.g. `UTC:yyyy-mm-dd HH:MM:ss.l o`.
   - Require a `SYS:` prefix to translate time to the local system's time zone. A
     shortcut `SYS:standard` to translate time to `yyyy-mm-dd HH:MM:ss.l o` in
     system time zone.
 - `--ignore` (`-i`): Ignore one or several keys, nested keys are supported with each property delimited by a dot character (`.`),
   keys may be escaped to target property names that contains the delimiter itself:
   (`-i time,hostname,req.headers,log\\.domain\\.corp/foo`)
+  Default: `hostname`.
 - `--hideObject` (`-H`): Hide objects from output (but not error object)
 - `--singleLine` (`-S`): Print each log message on a single line (errors will still be multi-line)
 - `--config`: Specify a path to a config file containing the pino-pretty options.  pino-pretty will attempt to read from a `.pino-prettyrc` in your current directory (`process.cwd`) if not specified

--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ const defaultOptions = {
   outputStream: process.stdout,
   customPrettifiers: {},
   hideObject: false,
+  ignore: 'hostname',
   singleLine: false
 }
 

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ const defaultOptions = {
   messageKey: MESSAGE_KEY,
   messageFormat: false,
   timestampKey: TIMESTAMP_KEY,
-  translateTime: false,
+  translateTime: true,
   useMetadata: false,
   outputStream: process.stdout,
   customPrettifiers: {},

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   DATE_FORMAT: 'yyyy-mm-dd HH:MM:ss.l o',
+  DATE_FORMAT_SIMPLE: 'HH:MM:ss.l',
 
   ERROR_LIKE_KEYS: ['err', 'error'],
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,7 +14,8 @@ const {
   LEVEL_LABEL,
   TIMESTAMP_KEY,
   LOGGER_KEYS,
-  LEVELS
+  LEVELS,
+  DATE_FORMAT_SIMPLE
 } = require('./constants')
 
 module.exports = {
@@ -74,7 +75,7 @@ function formatTime (epoch, translateTime = false) {
   }
 
   if (translateTime === true) {
-    return dateformat(instant, 'UTC:' + DATE_FORMAT)
+    return dateformat(instant, DATE_FORMAT_SIMPLE)
   }
 
   const upperFormat = translateTime.toUpperCase()

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,5 +1,7 @@
 'use strict'
 
+process.env.TZ = 'UTC'
+
 const { Writable } = require('readable-stream')
 const os = require('os')
 const test = require('tap').test
@@ -25,9 +27,11 @@ function prettyFactory (opts) {
   return _prettyFactory(opts)
 }
 
+// Date.prototype.getTimezoneOffset = function () { return 0 }
+
 // All dates are computed from 'Fri, 30 Mar 2018 17:35:28 GMT'
 const epoch = 1522431328992
-const formattedEpoch = '2018-03-30 17:35:28.992 +0000'
+const formattedEpoch = '17:35:28.992'
 const pid = process.pid
 const hostname = os.hostname()
 
@@ -56,7 +60,7 @@ test('basic prettifier tests', (t) => {
         const formatted = pretty(chunk.toString())
         t.equal(
           formatted,
-          `[${epoch}] INFO (${pid} on ${hostname}): foo\n`
+          `[${formattedEpoch}] INFO (${pid} on ${hostname}): foo\n`
         )
         cb()
       }
@@ -72,7 +76,7 @@ test('basic prettifier tests', (t) => {
         const formatted = pretty(chunk.toString())
         t.equal(
           formatted,
-          `[${epoch}] \u001B[32mINFO\u001B[39m (${pid} on ${hostname}): \u001B[36mfoo\u001B[39m\n`
+          `[${formattedEpoch}] \u001B[32mINFO\u001B[39m (${pid} on ${hostname}): \u001B[36mfoo\u001B[39m\n`
         )
         cb()
       }
@@ -86,7 +90,7 @@ test('basic prettifier tests', (t) => {
       write (formatted, enc, cb) {
         t.equal(
           formatted.toString(),
-          `INFO [${epoch}] (${pid} on ${hostname}): foo\n`
+          `INFO [${formattedEpoch}] (${pid} on ${hostname}): foo\n`
         )
         cb()
       }
@@ -108,7 +112,7 @@ test('basic prettifier tests', (t) => {
         const formatted = pretty(chunk.toString())
         t.equal(
           formatted,
-          `[${epoch}] INFO (${pid} on ${hostname}): baz\n`
+          `[${formattedEpoch}] INFO (${pid} on ${hostname}): baz\n`
         )
         cb()
       }
@@ -124,7 +128,7 @@ test('basic prettifier tests', (t) => {
         const formatted = pretty(chunk.toString())
         t.equal(
           formatted,
-          `[${epoch}] WARN (${pid} on ${hostname}): foo\n`
+          `[${formattedEpoch}] WARN (${pid} on ${hostname}): foo\n`
         )
         cb()
       }
@@ -147,7 +151,7 @@ test('basic prettifier tests', (t) => {
         const formatted = pretty(chunk.toString())
         t.equal(
           formatted,
-          `[${epoch}] LEVEL: ok (${pid} on ${hostname}): foo\n`
+          `[${formattedEpoch}] LEVEL: ok (${pid} on ${hostname}): foo\n`
         )
         cb()
       }
@@ -166,7 +170,7 @@ test('basic prettifier tests', (t) => {
         const formatted = pretty(chunk.toString())
         t.equal(
           formatted,
-          `[${epoch}] LEVEL: WARN (${pid} on ${hostname}): foo\n`
+          `[${formattedEpoch}] LEVEL: WARN (${pid} on ${hostname}): foo\n`
         )
         cb()
       }
@@ -185,7 +189,7 @@ test('basic prettifier tests', (t) => {
         const formatted = pretty(chunk.toString())
         t.equal(
           formatted,
-          `[${epoch}] INFO (NAME: logger/${pid} on ${hostname}): foo\n`
+          `[${formattedEpoch}] INFO (NAME: logger/${pid} on ${hostname}): foo\n`
         )
         cb()
       }
@@ -206,7 +210,7 @@ test('basic prettifier tests', (t) => {
         const formatted = pretty(chunk.toString())
         t.equal(
           formatted,
-          `[${epoch}] INFO (PID: ${pid} on HOSTNAME: ${hostname}): foo\n`
+          `[${formattedEpoch}] INFO (PID: ${pid} on HOSTNAME: ${hostname}): foo\n`
         )
         cb()
       }
@@ -225,7 +229,7 @@ test('basic prettifier tests', (t) => {
         const formatted = pretty(chunk.toString())
         t.equal(
           formatted,
-          `TIME: ${epoch} INFO (${pid} on ${hostname}): foo\n`
+          `TIME: ${formattedEpoch} INFO (${pid} on ${hostname}): foo\n`
         )
         cb()
       }
@@ -244,7 +248,7 @@ test('basic prettifier tests', (t) => {
         const formatted = pretty(chunk.toString())
         t.equal(
           formatted,
-          `[${epoch}] INFO (${pid} on ${hostname}) <CALLER: test.js:10>: foo\n`
+          `[${formattedEpoch}] INFO (${pid} on ${hostname}) <CALLER: test.js:10>: foo\n`
         )
         cb()
       }
@@ -496,7 +500,7 @@ test('basic prettifier tests', (t) => {
     const log = pino({ name: 'matteo' }, new Writable({
       write (chunk, enc, cb) {
         const formatted = pretty(chunk.toString())
-        t.equal(formatted, `[${epoch}] INFO (matteo/${pid} on ${hostname}): hello world\n`)
+        t.equal(formatted, `[${formattedEpoch}] INFO (matteo/${pid} on ${hostname}): hello world\n`)
         cb()
       }
     }))
@@ -563,7 +567,7 @@ test('basic prettifier tests', (t) => {
     const expected = [
       undefined,
       undefined,
-      `[${epoch}] INFO (${pid} on ${hostname}): baz\n`
+      `[${formattedEpoch}] INFO (${pid} on ${hostname}): baz\n`
     ]
     const log = pino({}, new Writable({
       write (chunk, enc, cb) {
@@ -586,8 +590,8 @@ test('basic prettifier tests', (t) => {
     const pretty = prettyFactory({ minimumLevel: 20, levelKey: 'bar' })
     const expected = [
       undefined,
-      `[${epoch}] DEBUG (${pid} on ${hostname}): bar\n`,
-      `[${epoch}] INFO (${pid} on ${hostname}): baz\n`
+      `[${formattedEpoch}] DEBUG (${pid} on ${hostname}): bar\n`,
+      `[${formattedEpoch}] INFO (${pid} on ${hostname}): baz\n`
     ]
     const log = pino({}, new Writable({
       write (chunk, enc, cb) {
@@ -615,7 +619,7 @@ test('basic prettifier tests', (t) => {
         const formatted = pretty(obj)
         t.equal(
           formatted,
-          `[${epoch}] INFO (${pid} on ${hostname}): foo\n`
+          `[${formattedEpoch}] INFO (${pid} on ${hostname}): foo\n`
         )
         cb()
       }
@@ -718,7 +722,7 @@ test('basic prettifier tests', (t) => {
       write (chunk, _, cb) {
         t.equal(
           chunk + '',
-          `[${epoch}] INFO (${pid} on ${hostname}):\n    a: {\n      "b": "c"\n    }\n    n: null\n`
+          `[${formattedEpoch}] INFO (${pid} on ${hostname}):\n    a: {\n      "b": "c"\n    }\n    n: null\n`
         )
         cb()
       }
@@ -742,14 +746,14 @@ test('basic prettifier tests', (t) => {
     t.plan(1)
     const pretty = prettyFactory({ ignore: 'pid,hostname' })
     const arst = pretty(`{"msg":"hello world", "pid":"${pid}", "hostname":"${hostname}", "time":${epoch}, "level":30}`)
-    t.equal(arst, `[${epoch}] INFO: hello world\n`)
+    t.equal(arst, `[${formattedEpoch}] INFO: hello world\n`)
   })
 
   t.test('ignores a single key', (t) => {
     t.plan(1)
     const pretty = prettyFactory({ ignore: 'pid' })
     const arst = pretty(`{"msg":"hello world", "pid":"${pid}", "hostname":"${hostname}", "time":${epoch}, "level":30}`)
-    t.equal(arst, `[${epoch}] INFO (on ${hostname}): hello world\n`)
+    t.equal(arst, `[${formattedEpoch}] INFO (on ${hostname}): hello world\n`)
   })
 
   t.test('ignores time', (t) => {
@@ -794,7 +798,7 @@ test('basic prettifier tests', (t) => {
         const formatted = pretty(chunk.toString())
         t.equal(
           formatted,
-          `[${epoch}] INFO (${pid} on ${hostname}) </tmp/script.js>: foo\n`
+          `[${formattedEpoch}] INFO (${pid} on ${hostname}) </tmp/script.js>: foo\n`
         )
         cb()
       }
@@ -806,7 +810,7 @@ test('basic prettifier tests', (t) => {
     t.plan(1)
     const pretty = prettyFactory({ timestampKey: '@timestamp' })
     const arst = pretty(`{"msg":"hello world", "@timestamp":${epoch}, "level":30}`)
-    t.equal(arst, `[${epoch}] INFO: hello world\n`)
+    t.equal(arst, `[${formattedEpoch}] INFO: hello world\n`)
   })
 
   t.test('keeps "v" key in log', (t) => {
@@ -828,7 +832,7 @@ test('basic prettifier tests', (t) => {
     const log = pino({}, new Writable({
       write (chunk, enc, cb) {
         const formatted = pretty(chunk.toString())
-        t.equal(formatted, `[${epoch}] INFO (${pid} on ${hostname}): hello world\n`)
+        t.equal(formatted, `[${formattedEpoch}] INFO (${pid} on ${hostname}): hello world\n`)
         cb()
       }
     }))
@@ -848,7 +852,7 @@ test('basic prettifier tests', (t) => {
     const log = pino({}, new Writable({
       write (chunk, enc, cb) {
         const formatted = pretty(chunk.toString())
-        t.equal(formatted, `[${epoch}] INFO (${pid} on ${hostname}): message {"extra":{"foo":"bar","number":42},"upper":"FOOBAR"}\n`)
+        t.equal(formatted, `[${formattedEpoch}] INFO (${pid} on ${hostname}): message {"extra":{"foo":"bar","number":42},"upper":"FOOBAR"}\n`)
 
         cb()
       }
@@ -862,7 +866,7 @@ test('basic prettifier tests', (t) => {
     const log = pino({}, new Writable({
       write (chunk, enc, cb) {
         const formatted = pretty(chunk.toString())
-        t.equal(formatted, `[${epoch}] INFO (${pid} on ${hostname}): message\n`)
+        t.equal(formatted, `[${formattedEpoch}] INFO (${pid} on ${hostname}): message\n`)
         cb()
       }
     }))
@@ -925,7 +929,7 @@ test('basic prettifier tests', (t) => {
 
     const formatted = fs.readFileSync(destination, 'utf8')
 
-    t.equal(formatted, `[${epoch}] INFO (${pid} on ${hostname}): message {"extra":{"foo":"bar","number":42},"upper":"FOOBAR"}\n`)
+    t.equal(formatted, `[${formattedEpoch}] INFO (${pid} on ${hostname}): message {"extra":{"foo":"bar","number":42},"upper":"FOOBAR"}\n`)
   })
 
   t.test('sync option', async (t) => {
@@ -948,7 +952,7 @@ test('basic prettifier tests', (t) => {
 
     const formatted = fs.readFileSync(destination, 'utf8')
 
-    t.equal(formatted, `[${epoch}] INFO (${pid} on ${hostname}): message {"extra":{"foo":"bar","number":42},"upper":"foobar"}\n`)
+    t.equal(formatted, `[${formattedEpoch}] INFO (${pid} on ${hostname}): message {"extra":{"foo":"bar","number":42},"upper":"foobar"}\n`)
   })
 
   t.end()

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -60,7 +60,7 @@ test('basic prettifier tests', (t) => {
         const formatted = pretty(chunk.toString())
         t.equal(
           formatted,
-          `[${formattedEpoch}] INFO (${pid} on ${hostname}): foo\n`
+          `[${formattedEpoch}] INFO (${pid}): foo\n`
         )
         cb()
       }
@@ -76,7 +76,7 @@ test('basic prettifier tests', (t) => {
         const formatted = pretty(chunk.toString())
         t.equal(
           formatted,
-          `[${formattedEpoch}] \u001B[32mINFO\u001B[39m (${pid} on ${hostname}): \u001B[36mfoo\u001B[39m\n`
+          `[${formattedEpoch}] \u001B[32mINFO\u001B[39m (${pid}): \u001B[36mfoo\u001B[39m\n`
         )
         cb()
       }
@@ -90,7 +90,7 @@ test('basic prettifier tests', (t) => {
       write (formatted, enc, cb) {
         t.equal(
           formatted.toString(),
-          `INFO [${formattedEpoch}] (${pid} on ${hostname}): foo\n`
+          `INFO [${formattedEpoch}] (${pid}): foo\n`
         )
         cb()
       }
@@ -112,7 +112,7 @@ test('basic prettifier tests', (t) => {
         const formatted = pretty(chunk.toString())
         t.equal(
           formatted,
-          `[${formattedEpoch}] INFO (${pid} on ${hostname}): baz\n`
+          `[${formattedEpoch}] INFO (${pid}): baz\n`
         )
         cb()
       }
@@ -128,7 +128,7 @@ test('basic prettifier tests', (t) => {
         const formatted = pretty(chunk.toString())
         t.equal(
           formatted,
-          `[${formattedEpoch}] WARN (${pid} on ${hostname}): foo\n`
+          `[${formattedEpoch}] WARN (${pid}): foo\n`
         )
         cb()
       }
@@ -151,7 +151,7 @@ test('basic prettifier tests', (t) => {
         const formatted = pretty(chunk.toString())
         t.equal(
           formatted,
-          `[${formattedEpoch}] LEVEL: ok (${pid} on ${hostname}): foo\n`
+          `[${formattedEpoch}] LEVEL: ok (${pid}): foo\n`
         )
         cb()
       }
@@ -170,7 +170,7 @@ test('basic prettifier tests', (t) => {
         const formatted = pretty(chunk.toString())
         t.equal(
           formatted,
-          `[${formattedEpoch}] LEVEL: WARN (${pid} on ${hostname}): foo\n`
+          `[${formattedEpoch}] LEVEL: WARN (${pid}): foo\n`
         )
         cb()
       }
@@ -189,7 +189,7 @@ test('basic prettifier tests', (t) => {
         const formatted = pretty(chunk.toString())
         t.equal(
           formatted,
-          `[${formattedEpoch}] INFO (NAME: logger/${pid} on ${hostname}): foo\n`
+          `[${formattedEpoch}] INFO (NAME: logger/${pid}): foo\n`
         )
         cb()
       }
@@ -204,7 +204,7 @@ test('basic prettifier tests', (t) => {
       hostname: (hostname) => `HOSTNAME: ${hostname}`,
       pid: (pid) => `PID: ${pid}`
     }
-    const pretty = prettyFactory({ customPrettifiers })
+    const pretty = prettyFactory({ customPrettifiers, ignore: '' })
     const log = pino({}, new Writable({
       write (chunk, enc, cb) {
         const formatted = pretty(chunk.toString())
@@ -229,7 +229,7 @@ test('basic prettifier tests', (t) => {
         const formatted = pretty(chunk.toString())
         t.equal(
           formatted,
-          `TIME: ${formattedEpoch} INFO (${pid} on ${hostname}): foo\n`
+          `TIME: ${formattedEpoch} INFO (${pid}): foo\n`
         )
         cb()
       }
@@ -248,7 +248,7 @@ test('basic prettifier tests', (t) => {
         const formatted = pretty(chunk.toString())
         t.equal(
           formatted,
-          `[${formattedEpoch}] INFO (${pid} on ${hostname}) <CALLER: test.js:10>: foo\n`
+          `[${formattedEpoch}] INFO (${pid}) <CALLER: test.js:10>: foo\n`
         )
         cb()
       }
@@ -267,7 +267,7 @@ test('basic prettifier tests', (t) => {
         const formatted = pretty(chunk.toString())
         t.equal(
           formatted,
-          `TIME: ${formattedEpoch} INFO (${pid} on ${hostname}): foo\n`
+          `TIME: ${formattedEpoch} INFO (${pid}): foo\n`
         )
         cb()
       }
@@ -283,7 +283,7 @@ test('basic prettifier tests', (t) => {
         const formatted = pretty(chunk.toString())
         t.equal(
           formatted,
-          `[${formattedEpoch}] INFO (${pid} on ${hostname}): foo\n`
+          `[${formattedEpoch}] INFO (${pid}): foo\n`
         )
         cb()
       }
@@ -301,7 +301,7 @@ test('basic prettifier tests', (t) => {
         const offset = dateformat(epoch, 'UTC:' + 'o')
         t.equal(
           formatted,
-          `[${utcHour}:35:28 ${offset}] INFO (${pid} on ${hostname}): foo\n`
+          `[${utcHour}:35:28 ${offset}] INFO (${pid}): foo\n`
         )
         cb()
       }
@@ -321,7 +321,7 @@ test('basic prettifier tests', (t) => {
         const offset = dateformat(epoch, 'o')
         t.equal(
           formatted,
-          `[${localDate} ${localHour}:${localMinute}:28.992 ${offset}] INFO (${pid} on ${hostname}): foo\n`
+          `[${localDate} ${localHour}:${localMinute}:28.992 ${offset}] INFO (${pid}): foo\n`
         )
         cb()
       }
@@ -343,7 +343,7 @@ test('basic prettifier tests', (t) => {
         const offset = dateformat(epoch, 'o')
         t.equal(
           formatted,
-          `[${localDate} ${localHour}:${localMinute}:28 ${offset}] INFO (${pid} on ${hostname}): foo\n`
+          `[${localDate} ${localHour}:${localMinute}:28 ${offset}] INFO (${pid}): foo\n`
         )
         cb()
       }
@@ -377,7 +377,7 @@ test('basic prettifier tests', (t) => {
     const pretty = prettyFactory()
     const name = 'test'
     const msg = 'hello world'
-    const regex = new RegExp('\\[.*\\] INFO \\(' + name + ' on ' + hostname + '\\): ' + msg)
+    const regex = new RegExp('\\[.*\\] INFO \\(' + name + '\\): ' + msg)
 
     const opts = {
       base: {
@@ -424,7 +424,7 @@ test('basic prettifier tests', (t) => {
     t.plan(1)
     const pretty = prettyFactory()
     const msg = 'hello world'
-    const regex = new RegExp('\\[.*\\] INFO \\(' + process.pid + ' on ' + hostname + '\\): ' + msg)
+    const regex = new RegExp('\\[.*\\] INFO \\(' + process.pid + '\\): ' + msg)
 
     const opts = {
       base: {
@@ -449,7 +449,7 @@ test('basic prettifier tests', (t) => {
     const log = pino({ timestamp: null }, new Writable({
       write (chunk, enc, cb) {
         const formatted = pretty(chunk.toString())
-        t.equal(formatted, `INFO (${pid} on ${hostname}): hello world\n`)
+        t.equal(formatted, `INFO (${pid}): hello world\n`)
         cb()
       }
     }))
@@ -500,7 +500,7 @@ test('basic prettifier tests', (t) => {
     const log = pino({ name: 'matteo' }, new Writable({
       write (chunk, enc, cb) {
         const formatted = pretty(chunk.toString())
-        t.equal(formatted, `[${formattedEpoch}] INFO (matteo/${pid} on ${hostname}): hello world\n`)
+        t.equal(formatted, `[${formattedEpoch}] INFO (matteo/${pid}): hello world\n`)
         cb()
       }
     }))
@@ -567,7 +567,7 @@ test('basic prettifier tests', (t) => {
     const expected = [
       undefined,
       undefined,
-      `[${formattedEpoch}] INFO (${pid} on ${hostname}): baz\n`
+      `[${formattedEpoch}] INFO (${pid}): baz\n`
     ]
     const log = pino({}, new Writable({
       write (chunk, enc, cb) {
@@ -590,8 +590,8 @@ test('basic prettifier tests', (t) => {
     const pretty = prettyFactory({ minimumLevel: 20, levelKey: 'bar' })
     const expected = [
       undefined,
-      `[${formattedEpoch}] DEBUG (${pid} on ${hostname}): bar\n`,
-      `[${formattedEpoch}] INFO (${pid} on ${hostname}): baz\n`
+      `[${formattedEpoch}] DEBUG (${pid}): bar\n`,
+      `[${formattedEpoch}] INFO (${pid}): baz\n`
     ]
     const log = pino({}, new Writable({
       write (chunk, enc, cb) {
@@ -619,7 +619,7 @@ test('basic prettifier tests', (t) => {
         const formatted = pretty(obj)
         t.equal(
           formatted,
-          `[${formattedEpoch}] INFO (${pid} on ${hostname}): foo\n`
+          `[${formattedEpoch}] INFO (${pid}): foo\n`
         )
         cb()
       }
@@ -722,7 +722,7 @@ test('basic prettifier tests', (t) => {
       write (chunk, _, cb) {
         t.equal(
           chunk + '',
-          `[${formattedEpoch}] INFO (${pid} on ${hostname}):\n    a: {\n      "b": "c"\n    }\n    n: null\n`
+          `[${formattedEpoch}] INFO (${pid}):\n    a: {\n      "b": "c"\n    }\n    n: null\n`
         )
         cb()
       }
@@ -798,7 +798,7 @@ test('basic prettifier tests', (t) => {
         const formatted = pretty(chunk.toString())
         t.equal(
           formatted,
-          `[${formattedEpoch}] INFO (${pid} on ${hostname}) </tmp/script.js>: foo\n`
+          `[${formattedEpoch}] INFO (${pid}) </tmp/script.js>: foo\n`
         )
         cb()
       }
@@ -832,7 +832,7 @@ test('basic prettifier tests', (t) => {
     const log = pino({}, new Writable({
       write (chunk, enc, cb) {
         const formatted = pretty(chunk.toString())
-        t.equal(formatted, `[${formattedEpoch}] INFO (${pid} on ${hostname}): hello world\n`)
+        t.equal(formatted, `[${formattedEpoch}] INFO (${pid}): hello world\n`)
         cb()
       }
     }))
@@ -852,7 +852,7 @@ test('basic prettifier tests', (t) => {
     const log = pino({}, new Writable({
       write (chunk, enc, cb) {
         const formatted = pretty(chunk.toString())
-        t.equal(formatted, `[${formattedEpoch}] INFO (${pid} on ${hostname}): message {"extra":{"foo":"bar","number":42},"upper":"FOOBAR"}\n`)
+        t.equal(formatted, `[${formattedEpoch}] INFO (${pid}): message {"extra":{"foo":"bar","number":42},"upper":"FOOBAR"}\n`)
 
         cb()
       }
@@ -866,7 +866,7 @@ test('basic prettifier tests', (t) => {
     const log = pino({}, new Writable({
       write (chunk, enc, cb) {
         const formatted = pretty(chunk.toString())
-        t.equal(formatted, `[${formattedEpoch}] INFO (${pid} on ${hostname}): message\n`)
+        t.equal(formatted, `[${formattedEpoch}] INFO (${pid}): message\n`)
         cb()
       }
     }))
@@ -929,7 +929,7 @@ test('basic prettifier tests', (t) => {
 
     const formatted = fs.readFileSync(destination, 'utf8')
 
-    t.equal(formatted, `[${formattedEpoch}] INFO (${pid} on ${hostname}): message {"extra":{"foo":"bar","number":42},"upper":"FOOBAR"}\n`)
+    t.equal(formatted, `[${formattedEpoch}] INFO (${pid}): message {"extra":{"foo":"bar","number":42},"upper":"FOOBAR"}\n`)
   })
 
   t.test('sync option', async (t) => {
@@ -952,7 +952,7 @@ test('basic prettifier tests', (t) => {
 
     const formatted = fs.readFileSync(destination, 'utf8')
 
-    t.equal(formatted, `[${formattedEpoch}] INFO (${pid} on ${hostname}): message {"extra":{"foo":"bar","number":42},"upper":"foobar"}\n`)
+    t.equal(formatted, `[${formattedEpoch}] INFO (${pid}): message {"extra":{"foo":"bar","number":42},"upper":"foobar"}\n`)
   })
 
   t.end()

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -27,7 +27,6 @@ function prettyFactory (opts) {
   return _prettyFactory(opts)
 }
 
-
 // All dates are computed from 'Fri, 30 Mar 2018 17:35:28 GMT'
 const epoch = 1522431328992
 const formattedEpoch = '17:35:28.992'

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -27,7 +27,6 @@ function prettyFactory (opts) {
   return _prettyFactory(opts)
 }
 
-// Date.prototype.getTimezoneOffset = function () { return 0 }
 
 // All dates are computed from 'Fri, 30 Mar 2018 17:35:28 GMT'
 const epoch = 1522431328992

--- a/test/cli-rc.test.js
+++ b/test/cli-rc.test.js
@@ -28,7 +28,7 @@ test('cli', (t) => {
     // Validate that the time has been translated
     child.on('error', t.threw)
     child.stdout.on('data', (data) => {
-      t.equal(data.toString(), '[17:35:28.992] INFO (42 on foo): hello world\n')
+      t.equal(data.toString(), '[17:35:28.992] INFO (42): hello world\n')
     })
     child.stdin.write(logLine)
     t.teardown(() => {
@@ -50,7 +50,7 @@ test('cli', (t) => {
     // Validate that the time has been translated
     child.on('error', t.threw)
     child.stdout.on('data', (data) => {
-      t.equal(data.toString(), '[17:35:28.992] INFO (42 on foo): hello world\n')
+      t.equal(data.toString(), '[17:35:28.992] INFO (42): hello world\n')
     })
     child.stdin.write(logLine)
     t.teardown(() => {
@@ -70,7 +70,7 @@ test('cli', (t) => {
     // Validate that the time has been translated
     child.on('error', t.threw)
     child.stdout.on('data', (data) => {
-      t.equal(data.toString(), '[17:35:28.992] INFO (42 on foo): hello world\n')
+      t.equal(data.toString(), '[17:35:28.992] INFO (42): hello world\n')
     })
     child.stdin.write(logLine)
     t.teardown(() => {
@@ -89,7 +89,7 @@ test('cli', (t) => {
     // Validate that the time has been translated
     child.on('error', t.threw)
     child.stdout.on('data', (data) => {
-      t.equal(data.toString(), '[17:35:28.992] INFO (42 on foo): hello world\n')
+      t.equal(data.toString(), '[17:35:28.992] INFO (42): hello world\n')
     })
     child.stdin.write(logLine)
     t.teardown(() => {
@@ -108,7 +108,7 @@ test('cli', (t) => {
     // Validate that the time has been translated
     child.on('error', t.threw)
     child.stdout.on('data', (data) => {
-      t.equal(data.toString(), '[17:35:28.992] INFO (42 on foo): hello world\n')
+      t.equal(data.toString(), '[17:35:28.992] INFO (42): hello world\n')
     })
     child.stdin.write(logLine)
     t.teardown(() => child.kill())
@@ -124,7 +124,7 @@ test('cli', (t) => {
     // Validate that the time has been translated
     child.on('error', t.threw)
     child.stdout.on('data', (data) => {
-      t.equal(data.toString(), '[17:35:28.992] INFO (42 on foo): hello world\n')
+      t.equal(data.toString(), '[17:35:28.992] INFO (42): hello world\n')
     })
     child.stdin.write(logLine)
     t.teardown(() => child.kill())
@@ -147,7 +147,7 @@ test('cli', (t) => {
       // Validate that the time has been translated and correct message key has been used
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), '[17:35:28.992] INFO (42 on foo): hello world\n')
+        t.equal(data.toString(), '[17:35:28.992] INFO (42): hello world\n')
       })
       child.stdin.write(logLine.replace(/"msg"/, '"new_msg"'))
       t.teardown(() => {

--- a/test/cli-rc.test.js
+++ b/test/cli-rc.test.js
@@ -1,5 +1,7 @@
 'use strict'
 
+process.env.TZ = 'UTC'
+
 const path = require('path')
 const spawn = require('child_process').spawn
 const test = require('tap').test
@@ -21,12 +23,12 @@ test('cli', (t) => {
     // Set translateTime: true on run configuration
     const configFile = path.join(tmpDir, 'pino-pretty.config.js')
     fs.writeFileSync(configFile, 'module.exports = { translateTime: true }')
-    const env = { TERM: 'dumb' }
+    const env = { TERM: 'dumb', TZ: 'UTC' }
     const child = spawn(process.argv[0], [bin], { env, cwd: tmpDir })
     // Validate that the time has been translated
     child.on('error', t.threw)
     child.stdout.on('data', (data) => {
-      t.equal(data.toString(), '[2018-03-30 17:35:28.992 +0000] INFO (42 on foo): hello world\n')
+      t.equal(data.toString(), '[17:35:28.992] INFO (42 on foo): hello world\n')
     })
     child.stdin.write(logLine)
     t.teardown(() => {
@@ -43,12 +45,12 @@ test('cli', (t) => {
     // Tell the loader to expect ESM modules
     const packageJsonFile = path.join(tmpDir, 'package.json')
     fs.writeFileSync(packageJsonFile, JSON.stringify({ type: 'module' }, null, 4))
-    const env = { TERM: 'dumb' }
+    const env = { TERM: ' dumb', TZ: 'UTC' }
     const child = spawn(process.argv[0], [bin], { env, cwd: tmpDir })
     // Validate that the time has been translated
     child.on('error', t.threw)
     child.stdout.on('data', (data) => {
-      t.equal(data.toString(), '[2018-03-30 17:35:28.992 +0000] INFO (42 on foo): hello world\n')
+      t.equal(data.toString(), '[17:35:28.992] INFO (42 on foo): hello world\n')
     })
     child.stdin.write(logLine)
     t.teardown(() => {
@@ -63,12 +65,12 @@ test('cli', (t) => {
     // Set translateTime: true on run configuration
     const configFile = path.join(tmpDir, '.pino-prettyrc')
     fs.writeFileSync(configFile, JSON.stringify({ translateTime: true }, null, 4))
-    const env = { TERM: 'dumb' }
+    const env = { TERM: ' dumb', TZ: 'UTC' }
     const child = spawn(process.argv[0], [bin], { env, cwd: tmpDir })
     // Validate that the time has been translated
     child.on('error', t.threw)
     child.stdout.on('data', (data) => {
-      t.equal(data.toString(), '[2018-03-30 17:35:28.992 +0000] INFO (42 on foo): hello world\n')
+      t.equal(data.toString(), '[17:35:28.992] INFO (42 on foo): hello world\n')
     })
     child.stdin.write(logLine)
     t.teardown(() => {
@@ -82,12 +84,12 @@ test('cli', (t) => {
     // Set translateTime: true on run configuration
     const configFile = path.join(tmpDir, '.pino-prettyrc.json')
     fs.writeFileSync(configFile, JSON.stringify({ translateTime: true }, null, 4))
-    const env = { TERM: 'dumb' }
+    const env = { TERM: ' dumb', TZ: 'UTC' }
     const child = spawn(process.argv[0], [bin], { env, cwd: tmpDir })
     // Validate that the time has been translated
     child.on('error', t.threw)
     child.stdout.on('data', (data) => {
-      t.equal(data.toString(), '[2018-03-30 17:35:28.992 +0000] INFO (42 on foo): hello world\n')
+      t.equal(data.toString(), '[17:35:28.992] INFO (42 on foo): hello world\n')
     })
     child.stdin.write(logLine)
     t.teardown(() => {
@@ -101,12 +103,12 @@ test('cli', (t) => {
     // Set translateTime: true on run configuration
     const configFile = path.join(tmpDir, 'pino-pretty.config.test.json')
     fs.writeFileSync(configFile, JSON.stringify({ translateTime: true }, null, 4))
-    const env = { TERM: 'dumb' }
+    const env = { TERM: ' dumb', TZ: 'UTC' }
     const child = spawn(process.argv[0], [bin, '--config', configFile], { env, cwd: tmpDir })
     // Validate that the time has been translated
     child.on('error', t.threw)
     child.stdout.on('data', (data) => {
-      t.equal(data.toString(), '[2018-03-30 17:35:28.992 +0000] INFO (42 on foo): hello world\n')
+      t.equal(data.toString(), '[17:35:28.992] INFO (42 on foo): hello world\n')
     })
     child.stdin.write(logLine)
     t.teardown(() => child.kill())
@@ -117,12 +119,12 @@ test('cli', (t) => {
     // Set translateTime: true on run configuration
     const configFile = path.join(tmpDir, 'pino-pretty.config.test.js')
     fs.writeFileSync(configFile, 'module.exports = { translateTime: true }')
-    const env = { TERM: 'dumb' }
+    const env = { TERM: ' dumb', TZ: 'UTC' }
     const child = spawn(process.argv[0], [bin, '--config', configFile], { env, cwd: tmpDir })
     // Validate that the time has been translated
     child.on('error', t.threw)
     child.stdout.on('data', (data) => {
-      t.equal(data.toString(), '[2018-03-30 17:35:28.992 +0000] INFO (42 on foo): hello world\n')
+      t.equal(data.toString(), '[17:35:28.992] INFO (42 on foo): hello world\n')
     })
     child.stdin.write(logLine)
     t.teardown(() => child.kill())
@@ -140,12 +142,12 @@ test('cli', (t) => {
         }
       `.trim())
       // Set messageKey: 'new_msg' using command line option
-      const env = { TERM: 'dumb' }
+      const env = { TERM: ' dumb', TZ: 'UTC' }
       const child = spawn(process.argv[0], [bin, optionName, 'new_msg'], { env, cwd: tmpDir })
       // Validate that the time has been translated and correct message key has been used
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), '[2018-03-30 17:35:28.992 +0000] INFO (42 on foo): hello world\n')
+        t.equal(data.toString(), '[17:35:28.992] INFO (42 on foo): hello world\n')
       })
       child.stdin.write(logLine.replace(/"msg"/, '"new_msg"'))
       t.teardown(() => {
@@ -165,12 +167,12 @@ test('cli', (t) => {
       }
     `.trim())
     // Set messageKey: 'new_msg' using command line option
-    const env = { TERM: 'dumb' }
+    const env = { TERM: ' dumb', TZ: 'UTC' }
     const child = spawn(process.argv[0], [bin], { env, cwd: tmpDir })
     // Validate that the time has been translated and correct message key has been used
     child.on('error', t.threw)
     child.stdout.on('data', (data) => {
-      t.equal(data.toString(), '[1594416696006] FATAL: There was an error starting the process.\n    QueryError: Error during sql query: syntax error at or near SELECTT\n        at /home/me/projects/example/sql.js\n        at /home/me/projects/example/index.js\n    querySql: SELECTT * FROM "test" WHERE id = $1;\n    queryArgs: 12\n')
+      t.equal(data.toString(), '[21:31:36.006] FATAL: There was an error starting the process.\n    QueryError: Error during sql query: syntax error at or near SELECTT\n        at /home/me/projects/example/sql.js\n        at /home/me/projects/example/index.js\n    querySql: SELECTT * FROM "test" WHERE id = $1;\n    queryArgs: 12\n')
     })
     child.stdin.write('{"level":60,"time":1594416696006,"msg":"There was an error starting the process.","type":"Error","stack":"QueryError: Error during sql query: syntax error at or near SELECTT\\n    at /home/me/projects/example/sql.js\\n    at /home/me/projects/example/index.js","querySql":"SELECTT * FROM \\"test\\" WHERE id = $1;","queryArgs":[12]}\n')
     t.teardown(() => {
@@ -182,7 +184,7 @@ test('cli', (t) => {
   t.test('throws on missing config file', (t) => {
     t.plan(2)
     const args = [bin, '--config', 'pino-pretty.config.missing.json']
-    const env = { TERM: 'dumb' }
+    const env = { TERM: ' dumb', TZ: 'UTC' }
     const child = spawn(process.argv[0], args, { env, cwd: tmpDir })
     child.on('close', (code) => t.equal(code, 1))
     child.stdout.pipe(process.stdout)
@@ -202,7 +204,7 @@ test('cli', (t) => {
     t.plan(2)
     const configFile = path.join(tmpDir, 'pino-pretty.config.js')
     fs.writeFileSync(configFile, 'module.exports = () => {}')
-    const env = { TERM: 'dumb' }
+    const env = { TERM: ' dumb', TZ: 'UTC' }
     const child = spawn(process.argv[0], [bin], { env, cwd: tmpDir })
     child.on('close', (code) => t.equal(code, 1))
     child.stdout.pipe(process.stdout)
@@ -222,7 +224,7 @@ test('cli', (t) => {
     const configFile = path.join(tmpDir, 'pino-pretty.config.invalid.js')
     fs.writeFileSync(configFile, 'module.exports = () => {}')
     const args = [bin, '--config', path.relative(tmpDir, configFile)]
-    const env = { TERM: 'dumb' }
+    const env = { TERM: ' dumb', TZ: 'UTC' }
     const child = spawn(process.argv[0], args, { env, cwd: tmpDir })
     child.on('close', (code) => t.equal(code, 1))
     child.stdout.pipe(process.stdout)
@@ -239,7 +241,7 @@ test('cli', (t) => {
 
   t.test('test help', (t) => {
     t.plan(1)
-    const env = { TERM: 'dumb' }
+    const env = { TERM: ' dumb', TZ: 'UTC' }
     const child = spawn(process.argv[0], [bin, '--help'], { env })
     const file = fs.readFileSync('help/help.txt').toString()
     child.on('error', t.threw)

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,5 +1,7 @@
 'use strict'
 
+process.env.TZ = 'UTC'
+
 const path = require('path')
 const spawn = require('child_process').spawn
 const test = require('tap').test
@@ -7,7 +9,8 @@ const test = require('tap').test
 const bin = require.resolve(path.join(__dirname, '..', 'bin.js'))
 const epoch = 1522431328992
 const logLine = '{"level":30,"time":1522431328992,"msg":"hello world","pid":42,"hostname":"foo"}\n'
-const env = { TERM: 'dumb' }
+const env = { TERM: 'dumb', TZ: 'UTC' }
+const formattedEpoch = '17:35:28.992'
 
 test('cli', (t) => {
   t.test('does basic reformatting', (t) => {
@@ -15,7 +18,7 @@ test('cli', (t) => {
     const child = spawn(process.argv[0], [bin], { env })
     child.on('error', t.threw)
     child.stdout.on('data', (data) => {
-      t.equal(data.toString(), `[${epoch}] INFO (42 on foo): hello world\n`)
+      t.equal(data.toString(), `[${formattedEpoch}] INFO (42 on foo): hello world\n`)
     })
     child.stdin.write(logLine)
     t.teardown(() => child.kill())
@@ -27,7 +30,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, optionName], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `INFO [${epoch}] (42 on foo): hello world\n`)
+        t.equal(data.toString(), `INFO [${formattedEpoch}] (42 on foo): hello world\n`)
       })
       child.stdin.write(logLine)
       t.teardown(() => child.kill())
@@ -40,7 +43,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, optionName], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), '[2018-03-30 17:35:28.992 +0000] INFO (42 on foo): hello world\n')
+        t.equal(data.toString(), `[${formattedEpoch}] INFO (42 on foo): hello world\n`)
       })
       child.stdin.write(logLine)
       t.teardown(() => child.kill())
@@ -53,7 +56,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, optionName, 'pid,hostname'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), '[1522431328992] INFO: hello world\n')
+        t.equal(data.toString(), `[${formattedEpoch}] INFO: hello world\n`)
       })
       child.stdin.write(logLine)
       t.teardown(() => child.kill())
@@ -67,7 +70,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, optionName, 'err:99,info:1'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${epoch}] INFO (42 on foo): hello world\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] INFO (42 on foo): hello world\n`)
       })
       child.stdin.write(logLine)
       t.teardown(() => child.kill())
@@ -79,7 +82,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, optionName, 'err:99,info'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${epoch}] INFO (42 on foo): hello world\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] INFO (42 on foo): hello world\n`)
       })
       child.stdin.write(logLine)
       t.teardown(() => child.kill())
@@ -90,7 +93,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, '--minimumLevel', 'err', optionName, 'err:99,info:1'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${epoch}] ERR (42 on foo): hello world\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] ERR (42 on foo): hello world\n`)
       })
       child.stdin.write('{"level":1,"time":1522431328992,"msg":"hello world","pid":42,"hostname":"foo"}\n')
       child.stdin.write('{"level":99,"time":1522431328992,"msg":"hello world","pid":42,"hostname":"foo"}\n')
@@ -102,7 +105,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, '--minimumLevel', 'custom', '--useOnlyCustomProps', 'false', optionName, 'custom:99,info:1'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${epoch}] CUSTOM (42 on foo): hello world\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] CUSTOM (42 on foo): hello world\n`)
       })
       child.stdin.write('{"level":1,"time":1522431328992,"msg":"hello world","pid":42,"hostname":"foo"}\n')
       child.stdin.write('{"level":99,"time":1522431328992,"msg":"hello world","pid":42,"hostname":"foo"}\n')
@@ -114,7 +117,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, '--minimumLevel', 'custom', '--useOnlyCustomProps', 'true', optionName, 'custom:99,info:1'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${epoch}] CUSTOM (42 on foo): hello world\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] CUSTOM (42 on foo): hello world\n`)
       })
       child.stdin.write('{"level":1,"time":1522431328992,"msg":"hello world","pid":42,"hostname":"foo"}\n')
       child.stdin.write('{"level":99,"time":1522431328992,"msg":"hello world","pid":42,"hostname":"foo"}\n')
@@ -128,7 +131,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, optionName, 'info:blue,message:red'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${epoch}] INFO (42 on foo): hello world\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] INFO (42 on foo): hello world\n`)
       })
       child.stdin.write(logLine)
       t.teardown(() => child.kill())
@@ -140,7 +143,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, '--customLevels', 'err:99,info', optionName, 'info:blue,message:red'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${epoch}] INFO (42 on foo): hello world\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] INFO (42 on foo): hello world\n`)
       })
       child.stdin.write(logLine)
       t.teardown(() => child.kill())
@@ -153,7 +156,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, '--customColors', 'err:blue,info:red', optionName, 'false'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${epoch}] INFO (42 on foo): hello world\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] INFO (42 on foo): hello world\n`)
       })
       child.stdin.write(logLine)
       t.teardown(() => child.kill())
@@ -164,7 +167,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, '--customColors', 'err:blue,info:red', optionName, 'true'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${epoch}] INFO (42 on foo): hello world\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] INFO (42 on foo): hello world\n`)
       })
       child.stdin.write(logLine)
       t.teardown(() => child.kill())
@@ -175,7 +178,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, '--customLevels', 'err:99,custom:30', optionName, 'true'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${epoch}] CUSTOM (42 on foo): hello world\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] CUSTOM (42 on foo): hello world\n`)
       })
       child.stdin.write(logLine)
       t.teardown(() => child.kill())
@@ -186,7 +189,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, optionName, 'true'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${epoch}] INFO (42 on foo): hello world\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] INFO (42 on foo): hello world\n`)
       })
       child.stdin.write(logLine)
       t.teardown(() => child.kill())
@@ -197,7 +200,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, '--customLevels', 'err:99,custom:25', optionName, 'false'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${epoch}] INFO (42 on foo): hello world\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] INFO (42 on foo): hello world\n`)
       })
       child.stdin.write(logLine)
       t.teardown(() => child.kill())
@@ -208,7 +211,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, optionName, 'false'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${epoch}] INFO (42 on foo): hello world\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] INFO (42 on foo): hello world\n`)
       })
       child.stdin.write(logLine)
       t.teardown(() => child.kill())
@@ -220,7 +223,7 @@ test('cli', (t) => {
     const child = spawn(process.argv[0], [bin, '-i', 'log\\.domain\\.corp/foo'], { env })
     child.on('error', t.threw)
     child.stdout.on('data', (data) => {
-      t.equal(data.toString(), '[1522431328992] INFO: hello world\n')
+      t.equal(data.toString(), `[${formattedEpoch}] INFO: hello world\n`)
     })
     const logLine = '{"level":30,"time":1522431328992,"msg":"hello world","log.domain.corp/foo":"bar"}\n'
     child.stdin.write(logLine)
@@ -267,7 +270,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, optionName, '@timestamp'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), '[1522431328992] INFO: hello world\n')
+        t.equal(data.toString(), `[${formattedEpoch}] INFO: hello world\n`)
       })
       const logLine = '{"level":30,"@timestamp":1522431328992,"msg":"hello world"}\n'
       child.stdin.write(logLine)
@@ -288,7 +291,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, optionName], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${epoch}] INFO (42 on foo): hello world {"extra":{"foo":"bar","number":42}}\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] INFO (42 on foo): hello world {"extra":{"foo":"bar","number":42}}\n`)
       })
       child.stdin.write(logLineWithExtra)
       t.teardown(() => child.kill())
@@ -311,9 +314,20 @@ test('cli', (t) => {
     const child = spawn(process.argv[0], [bin, '-S', '-i', 'extra.foo,extra.nested,extra.nested.miss'], { env })
     child.on('error', t.threw)
     child.stdout.on('data', (data) => {
-      t.equal(data.toString(), `[${epoch}] INFO (42 on foo): hello world {"extra":{"number":42}}\n`)
+      t.equal(data.toString(), `[${formattedEpoch}] INFO (42 on foo): hello world {"extra":{"number":42}}\n`)
     })
     child.stdin.write(logLineNested)
+    t.teardown(() => child.kill())
+  })
+
+  t.test('change TZ', (t) => {
+    t.plan(1)
+    const child = spawn(process.argv[0], [bin], { env: { ...env, TZ: 'Europe/Amsterdam' } })
+    child.on('error', t.threw)
+    child.stdout.on('data', (data) => {
+      t.equal(data.toString(), '[19:35:28.992] INFO (42 on foo): hello world\n')
+    })
+    child.stdin.write(logLine)
     t.teardown(() => child.kill())
   })
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -18,7 +18,7 @@ test('cli', (t) => {
     const child = spawn(process.argv[0], [bin], { env })
     child.on('error', t.threw)
     child.stdout.on('data', (data) => {
-      t.equal(data.toString(), `[${formattedEpoch}] INFO (42 on foo): hello world\n`)
+      t.equal(data.toString(), `[${formattedEpoch}] INFO (42): hello world\n`)
     })
     child.stdin.write(logLine)
     t.teardown(() => child.kill())
@@ -30,7 +30,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, optionName], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `INFO [${formattedEpoch}] (42 on foo): hello world\n`)
+        t.equal(data.toString(), `INFO [${formattedEpoch}] (42): hello world\n`)
       })
       child.stdin.write(logLine)
       t.teardown(() => child.kill())
@@ -43,7 +43,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, optionName], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${formattedEpoch}] INFO (42 on foo): hello world\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] INFO (42): hello world\n`)
       })
       child.stdin.write(logLine)
       t.teardown(() => child.kill())
@@ -70,7 +70,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, optionName, 'err:99,info:1'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${formattedEpoch}] INFO (42 on foo): hello world\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] INFO (42): hello world\n`)
       })
       child.stdin.write(logLine)
       t.teardown(() => child.kill())
@@ -82,7 +82,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, optionName, 'err:99,info'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${formattedEpoch}] INFO (42 on foo): hello world\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] INFO (42): hello world\n`)
       })
       child.stdin.write(logLine)
       t.teardown(() => child.kill())
@@ -93,7 +93,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, '--minimumLevel', 'err', optionName, 'err:99,info:1'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${formattedEpoch}] ERR (42 on foo): hello world\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] ERR (42): hello world\n`)
       })
       child.stdin.write('{"level":1,"time":1522431328992,"msg":"hello world","pid":42,"hostname":"foo"}\n')
       child.stdin.write('{"level":99,"time":1522431328992,"msg":"hello world","pid":42,"hostname":"foo"}\n')
@@ -105,7 +105,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, '--minimumLevel', 'custom', '--useOnlyCustomProps', 'false', optionName, 'custom:99,info:1'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${formattedEpoch}] CUSTOM (42 on foo): hello world\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] CUSTOM (42): hello world\n`)
       })
       child.stdin.write('{"level":1,"time":1522431328992,"msg":"hello world","pid":42,"hostname":"foo"}\n')
       child.stdin.write('{"level":99,"time":1522431328992,"msg":"hello world","pid":42,"hostname":"foo"}\n')
@@ -117,7 +117,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, '--minimumLevel', 'custom', '--useOnlyCustomProps', 'true', optionName, 'custom:99,info:1'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${formattedEpoch}] CUSTOM (42 on foo): hello world\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] CUSTOM (42): hello world\n`)
       })
       child.stdin.write('{"level":1,"time":1522431328992,"msg":"hello world","pid":42,"hostname":"foo"}\n')
       child.stdin.write('{"level":99,"time":1522431328992,"msg":"hello world","pid":42,"hostname":"foo"}\n')
@@ -131,7 +131,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, optionName, 'info:blue,message:red'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${formattedEpoch}] INFO (42 on foo): hello world\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] INFO (42): hello world\n`)
       })
       child.stdin.write(logLine)
       t.teardown(() => child.kill())
@@ -143,7 +143,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, '--customLevels', 'err:99,info', optionName, 'info:blue,message:red'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${formattedEpoch}] INFO (42 on foo): hello world\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] INFO (42): hello world\n`)
       })
       child.stdin.write(logLine)
       t.teardown(() => child.kill())
@@ -156,7 +156,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, '--customColors', 'err:blue,info:red', optionName, 'false'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${formattedEpoch}] INFO (42 on foo): hello world\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] INFO (42): hello world\n`)
       })
       child.stdin.write(logLine)
       t.teardown(() => child.kill())
@@ -167,7 +167,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, '--customColors', 'err:blue,info:red', optionName, 'true'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${formattedEpoch}] INFO (42 on foo): hello world\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] INFO (42): hello world\n`)
       })
       child.stdin.write(logLine)
       t.teardown(() => child.kill())
@@ -178,7 +178,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, '--customLevels', 'err:99,custom:30', optionName, 'true'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${formattedEpoch}] CUSTOM (42 on foo): hello world\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] CUSTOM (42): hello world\n`)
       })
       child.stdin.write(logLine)
       t.teardown(() => child.kill())
@@ -189,7 +189,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, optionName, 'true'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${formattedEpoch}] INFO (42 on foo): hello world\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] INFO (42): hello world\n`)
       })
       child.stdin.write(logLine)
       t.teardown(() => child.kill())
@@ -200,7 +200,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, '--customLevels', 'err:99,custom:25', optionName, 'false'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${formattedEpoch}] INFO (42 on foo): hello world\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] INFO (42): hello world\n`)
       })
       child.stdin.write(logLine)
       t.teardown(() => child.kill())
@@ -211,7 +211,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, optionName, 'false'], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${formattedEpoch}] INFO (42 on foo): hello world\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] INFO (42): hello world\n`)
       })
       child.stdin.write(logLine)
       t.teardown(() => child.kill())
@@ -291,7 +291,7 @@ test('cli', (t) => {
       const child = spawn(process.argv[0], [bin, optionName], { env })
       child.on('error', t.threw)
       child.stdout.on('data', (data) => {
-        t.equal(data.toString(), `[${formattedEpoch}] INFO (42 on foo): hello world {"extra":{"foo":"bar","number":42}}\n`)
+        t.equal(data.toString(), `[${formattedEpoch}] INFO (42): hello world {"extra":{"foo":"bar","number":42}}\n`)
       })
       child.stdin.write(logLineWithExtra)
       t.teardown(() => child.kill())
@@ -325,7 +325,7 @@ test('cli', (t) => {
     const child = spawn(process.argv[0], [bin], { env: { ...env, TZ: 'Europe/Amsterdam' } })
     child.on('error', t.threw)
     child.stdout.on('data', (data) => {
-      t.equal(data.toString(), '[19:35:28.992] INFO (42 on foo): hello world\n')
+      t.equal(data.toString(), '[19:35:28.992] INFO (42): hello world\n')
     })
     child.stdin.write(logLine)
     t.teardown(() => child.kill())

--- a/test/crlf.test.js
+++ b/test/crlf.test.js
@@ -1,5 +1,7 @@
 'use strict'
 
+process.env.TZ = 'UTC'
+
 const test = require('tap').test
 const _prettyFactory = require('../').prettyFactory
 

--- a/test/error-objects.test.js
+++ b/test/error-objects.test.js
@@ -1,5 +1,7 @@
 'use strict'
 
+process.env.TZ = 'UTC'
+
 const Writable = require('stream').Writable
 const os = require('os')
 const test = require('tap').test
@@ -18,6 +20,7 @@ function prettyFactory (opts) {
 
 // All dates are computed from 'Fri, 30 Mar 2018 17:35:28 GMT'
 const epoch = 1522431328992
+const formattedEpoch = '17:35:28.992'
 const pid = process.pid
 const hostname = os.hostname()
 
@@ -43,7 +46,7 @@ test('error like objects tests', { only: true }, (t) => {
         const formatted = pretty(chunk.toString())
         const lines = formatted.split('\n')
         t.equal(lines.length, expected.length + 6)
-        t.equal(lines[0], `[${epoch}] INFO (${pid} on ${hostname}): hello world`)
+        t.equal(lines[0], `[${formattedEpoch}] INFO (${pid} on ${hostname}): hello world`)
         cb()
       }
     }))
@@ -94,7 +97,7 @@ test('error like objects tests', { only: true }, (t) => {
         const formatted = pretty(chunk.toString())
         const lines = formatted.split('\n')
         t.equal(lines.length, expected.length + 6)
-        t.equal(lines[0], `[${epoch}] INFO (${pid} on ${hostname}): hello world`)
+        t.equal(lines[0], `[${formattedEpoch}] INFO (${pid} on ${hostname}): hello world`)
         t.match(lines[1], /\s{4}err: {/)
         t.match(lines[2], /\s{6}"type": "Error",/)
         t.match(lines[3], /\s{6}"message": "hello world",/)
@@ -129,7 +132,7 @@ test('error like objects tests', { only: true }, (t) => {
         const formatted = pretty(chunk.toString())
         const lines = formatted.split('\n')
         t.equal(lines.length, expected.length + 5)
-        t.equal(lines[0], `[${epoch}] INFO (${pid} on ${hostname}): hello world {"extra":{"a":1,"b":2}}`)
+        t.equal(lines[0], `[${formattedEpoch}] INFO (${pid} on ${hostname}): hello world {"extra":{"a":1,"b":2}}`)
         t.match(lines[1], /\s{4}err: {/)
         t.match(lines[2], /\s{6}"type": "Error",/)
         t.match(lines[3], /\s{6}"message": "hello world",/)
@@ -163,7 +166,7 @@ test('error like objects tests', { only: true }, (t) => {
         const formatted = pretty(chunk.toString())
         const lines = formatted.split('\n')
         t.equal(lines.length, 3)
-        t.equal(lines[0], `[${epoch}] INFO (${pid} on ${hostname}): hello world`)
+        t.equal(lines[0], `[${formattedEpoch}] INFO (${pid} on ${hostname}): hello world`)
         t.equal(lines[1], '    err: error is hello world')
         t.equal(lines[2], '')
 
@@ -190,7 +193,7 @@ test('error like objects tests', { only: true }, (t) => {
         const formatted = pretty(chunk.toString())
         const lines = formatted.split('\n')
         t.equal(lines.length, expected.length + 6)
-        t.equal(lines[0], `[${epoch}] INFO (${pid} on ${hostname}): hello world`)
+        t.equal(lines[0], `[${formattedEpoch}] INFO (${pid} on ${hostname}): hello world`)
         t.match(lines[1], /\s{4}err: {$/)
         t.match(lines[2], /\s{6}"type": "Error",$/)
         t.match(lines[3], /\s{6}"message": "hello world",$/)
@@ -220,7 +223,7 @@ test('error like objects tests', { only: true }, (t) => {
         const formatted = pretty(chunk.toString())
         const lines = formatted.split('\n')
         t.equal(lines.length, expected.length + 7)
-        t.equal(lines[0], `[${epoch}] INFO (${pid} on ${hostname}): hello world`)
+        t.equal(lines[0], `[${formattedEpoch}] INFO (${pid} on ${hostname}): hello world`)
         t.match(lines[1], /\s{4}err: {/)
         t.match(lines[2], /\s{6}"type": "Error",/)
         t.match(lines[3], /\s{6}"message": "hello world",/)
@@ -293,7 +296,7 @@ test('error like objects tests', { only: true }, (t) => {
         const formatted = pretty(chunk.toString())
         const lines = formatted.split('\n')
         t.equal(lines.length, expected.length + 1)
-        t.equal(lines[0], `[${epoch}] INFO (${pid} on ${hostname}): ${expected[0]}`)
+        t.equal(lines[0], `[${formattedEpoch}] INFO (${pid} on ${hostname}): ${expected[0]}`)
         t.equal(lines[1], `    ${expected[1]}`)
         t.equal(lines[2], `    ${expected[2]}`)
         cb()

--- a/test/error-objects.test.js
+++ b/test/error-objects.test.js
@@ -3,7 +3,6 @@
 process.env.TZ = 'UTC'
 
 const Writable = require('stream').Writable
-const os = require('os')
 const test = require('tap').test
 const pino = require('pino')
 const serializers = pino.stdSerializers
@@ -22,9 +21,8 @@ function prettyFactory (opts) {
 const epoch = 1522431328992
 const formattedEpoch = '17:35:28.992'
 const pid = process.pid
-const hostname = os.hostname()
 
-test('error like objects tests', { only: true }, (t) => {
+test('error like objects tests', (t) => {
   t.beforeEach(() => {
     Date.originalNow = Date.now
     Date.now = () => epoch
@@ -46,7 +44,7 @@ test('error like objects tests', { only: true }, (t) => {
         const formatted = pretty(chunk.toString())
         const lines = formatted.split('\n')
         t.equal(lines.length, expected.length + 6)
-        t.equal(lines[0], `[${formattedEpoch}] INFO (${pid} on ${hostname}): hello world`)
+        t.equal(lines[0], `[${formattedEpoch}] INFO (${pid}): hello world`)
         cb()
       }
     }))
@@ -97,7 +95,7 @@ test('error like objects tests', { only: true }, (t) => {
         const formatted = pretty(chunk.toString())
         const lines = formatted.split('\n')
         t.equal(lines.length, expected.length + 6)
-        t.equal(lines[0], `[${formattedEpoch}] INFO (${pid} on ${hostname}): hello world`)
+        t.equal(lines[0], `[${formattedEpoch}] INFO (${pid}): hello world`)
         t.match(lines[1], /\s{4}err: {/)
         t.match(lines[2], /\s{6}"type": "Error",/)
         t.match(lines[3], /\s{6}"message": "hello world",/)
@@ -132,7 +130,7 @@ test('error like objects tests', { only: true }, (t) => {
         const formatted = pretty(chunk.toString())
         const lines = formatted.split('\n')
         t.equal(lines.length, expected.length + 5)
-        t.equal(lines[0], `[${formattedEpoch}] INFO (${pid} on ${hostname}): hello world {"extra":{"a":1,"b":2}}`)
+        t.equal(lines[0], `[${formattedEpoch}] INFO (${pid}): hello world {"extra":{"a":1,"b":2}}`)
         t.match(lines[1], /\s{4}err: {/)
         t.match(lines[2], /\s{6}"type": "Error",/)
         t.match(lines[3], /\s{6}"message": "hello world",/)
@@ -166,7 +164,7 @@ test('error like objects tests', { only: true }, (t) => {
         const formatted = pretty(chunk.toString())
         const lines = formatted.split('\n')
         t.equal(lines.length, 3)
-        t.equal(lines[0], `[${formattedEpoch}] INFO (${pid} on ${hostname}): hello world`)
+        t.equal(lines[0], `[${formattedEpoch}] INFO (${pid}): hello world`)
         t.equal(lines[1], '    err: error is hello world')
         t.equal(lines[2], '')
 
@@ -193,7 +191,7 @@ test('error like objects tests', { only: true }, (t) => {
         const formatted = pretty(chunk.toString())
         const lines = formatted.split('\n')
         t.equal(lines.length, expected.length + 6)
-        t.equal(lines[0], `[${formattedEpoch}] INFO (${pid} on ${hostname}): hello world`)
+        t.equal(lines[0], `[${formattedEpoch}] INFO (${pid}): hello world`)
         t.match(lines[1], /\s{4}err: {$/)
         t.match(lines[2], /\s{6}"type": "Error",$/)
         t.match(lines[3], /\s{6}"message": "hello world",$/)
@@ -223,7 +221,7 @@ test('error like objects tests', { only: true }, (t) => {
         const formatted = pretty(chunk.toString())
         const lines = formatted.split('\n')
         t.equal(lines.length, expected.length + 7)
-        t.equal(lines[0], `[${formattedEpoch}] INFO (${pid} on ${hostname}): hello world`)
+        t.equal(lines[0], `[${formattedEpoch}] INFO (${pid}): hello world`)
         t.match(lines[1], /\s{4}err: {/)
         t.match(lines[2], /\s{6}"type": "Error",/)
         t.match(lines[3], /\s{6}"message": "hello world",/)
@@ -296,7 +294,7 @@ test('error like objects tests', { only: true }, (t) => {
         const formatted = pretty(chunk.toString())
         const lines = formatted.split('\n')
         t.equal(lines.length, expected.length + 1)
-        t.equal(lines[0], `[${formattedEpoch}] INFO (${pid} on ${hostname}): ${expected[0]}`)
+        t.equal(lines[0], `[${formattedEpoch}] INFO (${pid}): ${expected[0]}`)
         t.equal(lines[1], `    ${expected[1]}`)
         t.equal(lines[2], `    ${expected[2]}`)
         cb()

--- a/test/lib/utils.internals.test.js
+++ b/test/lib/utils.internals.test.js
@@ -1,5 +1,7 @@
 'use strict'
 
+process.env.TZ = 'UTC'
+
 const tap = require('tap')
 const fastCopy = require('fast-copy')
 const stringifySafe = require('fast-safe-stringify')
@@ -33,7 +35,7 @@ tap.test('#formatTime', t => {
 
   t.test('translates epoch milliseconds if `translateTime` is `true`', async t => {
     const formattedTime = internals.formatTime(epochMS, true)
-    t.equal(formattedTime, '2019-04-06 17:30:00.000 +0000')
+    t.equal(formattedTime, '17:30:00.000')
   })
 
   t.test('translates epoch milliseconds to UTC string given format', async t => {
@@ -58,7 +60,7 @@ tap.test('#formatTime', t => {
 
   t.test('translates date string if `translateTime` is `true`', async t => {
     const formattedTime = internals.formatTime(dateStr, true)
-    t.equal(formattedTime, '2019-04-06 17:30:00.000 +0000')
+    t.equal(formattedTime, '17:30:00.000')
   })
 
   t.test('translates date string to UTC string given format', async t => {

--- a/test/lib/utils.public.test.js
+++ b/test/lib/utils.public.test.js
@@ -1,5 +1,7 @@
 'use strict'
 
+process.env.TZ = 'UTC'
+
 const tap = require('tap')
 const getColorizer = require('../../lib/colors')
 const utils = require('../../lib/utils')
@@ -294,7 +296,7 @@ tap.test('prettifyTime', t => {
   t.test('returns prettified formatted time from custom field', async t => {
     const log = { customtime: 1554642900000 }
     let str = prettifyTime({ log, translateFormat: true, timestampKey: 'customtime' })
-    t.equal(str, '[2019-04-07 13:15:00.000 +0000]')
+    t.equal(str, '[13:15:00.000]')
 
     str = prettifyTime({ log, translateFormat: false, timestampKey: 'customtime' })
     t.equal(str, '[1554642900000]')
@@ -303,19 +305,19 @@ tap.test('prettifyTime', t => {
   t.test('returns prettified formatted time', async t => {
     let log = { time: 1554642900000 }
     let str = prettifyTime({ log, translateFormat: true })
-    t.equal(str, '[2019-04-07 13:15:00.000 +0000]')
+    t.equal(str, '[13:15:00.000]')
 
     log = { timestamp: 1554642900000 }
     str = prettifyTime({ log, translateFormat: true })
-    t.equal(str, '[2019-04-07 13:15:00.000 +0000]')
+    t.equal(str, '[13:15:00.000]')
 
     log = { time: '2019-04-07T09:15:00.000-04:00' }
     str = prettifyTime({ log, translateFormat: true })
-    t.equal(str, '[2019-04-07 13:15:00.000 +0000]')
+    t.equal(str, '[13:15:00.000]')
 
     log = { timestamp: '2019-04-07T09:15:00.000-04:00' }
     str = prettifyTime({ log, translateFormat: true })
-    t.equal(str, '[2019-04-07 13:15:00.000 +0000]')
+    t.equal(str, '[13:15:00.000]')
 
     log = { time: 1554642900000 }
     str = prettifyTime({ log, translateFormat: 'd mmm yyyy H:MM' })
@@ -377,8 +379,8 @@ tap.test('prettifyTime', t => {
       log: { time: '2 days ago', msg: 'foo' },
       translateFormat: true
     })
-    t.same(asString, '[2018-03-30 17:35:28.992 +0000]')
-    t.same(asNumber, '[2018-03-30 17:35:28.992 +0000]')
+    t.same(asString, '[17:35:28.992]')
+    t.same(asNumber, '[17:35:28.992]')
     t.same(invalid, '[2 days ago]')
   })
 


### PR DESCRIPTION
We say that `pino-pretty` is a _development_ tool, however it's very verbose in its default settings to use for local development. In this PR I simplified it a bit:

1. Use the local timezone and just print the time. If I'm developing code I want to reason on my own timezone and I'm not interested in what day it is.
2. remove the hostname as it's unlikely to change given that's my development machine.

This was inspired by https://github.com/fastify/fastify-cli/issues/536