### PR TITLE
Fix the include flag example in help.txt

### DIFF
--- a/help/help.txt
+++ b/help/help.txt
@@ -60,7 +60,7 @@
     $ cat log | pino-pretty -i pid,hostname
     
     - Prettify logs but only print time and level
-    $ cat log | pino-pretty -i time,level
+    $ cat log | pino-pretty -I time,level
 
     - Loads options from a config file
     $ cat log | pino-pretty --config=/path/to/config.json


### PR DESCRIPTION
Fix the wrong example of the include flag in help.txt.

Thanks to @glensc spotting the issue in a previous [PR](https://github.com/pinojs/pino-pretty/pull/373/files#r958686611).