### PR TITLE
feat: adding possibility to pass an object as parameter to customLevels

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -175,6 +175,15 @@ interface PrettyOptions_ {
    * ```
    */
   customPrettifiers?: Record<string, PinoPretty.Prettifier>;
+  /**
+   * Change the level names and values to an user custom preset.
+   *
+   * Can be a CSV string in 'level_name:level_value' format or an object.
+   *
+   * @example ( CSV ) customLevels: 'info:10,some_level:40'
+   * @example ( Object ) customLevels: { info: 10, some_level: 40 }
+   */
+  customLevels?: string|object;
 }
 
 declare namespace PinoPretty {

--- a/index.js
+++ b/index.js
@@ -16,7 +16,9 @@ const {
   prettifyObject,
   prettifyTime,
   buildSafeSonicBoom,
-  filterLog
+  filterLog,
+  handleCustomlevelsOpts,
+  handleCustomlevelNamesOpts
 } = require('./lib/utils')
 
 const jsonParser = input => {
@@ -62,28 +64,9 @@ function prettyFactory (options) {
   const errorLikeObjectKeys = opts.errorLikeObjectKeys
   const errorProps = opts.errorProps.split(',')
   const useOnlyCustomProps = typeof opts.useOnlyCustomProps === 'boolean' ? opts.useOnlyCustomProps : opts.useOnlyCustomProps === 'true'
-  const customLevels = opts.customLevels
-    ? opts.customLevels
-      .split(',')
-      .reduce((agg, value, idx) => {
-        const [levelName, levelIdx = idx] = value.split(':')
+  const customLevels = handleCustomlevelsOpts(opts.customLevels)
+  const customLevelNames = handleCustomlevelNamesOpts(opts.customLevels)
 
-        agg[levelIdx] = levelName.toUpperCase()
-
-        return agg
-      }, { default: 'USERLVL' })
-    : {}
-  const customLevelNames = opts.customLevels
-    ? opts.customLevels
-      .split(',')
-      .reduce((agg, value, idx) => {
-        const [levelName, levelIdx = idx] = value.split(':')
-
-        agg[levelName.toLowerCase()] = levelIdx
-
-        return agg
-      }, {})
-    : {}
   const customColors = opts.customColors
     ? opts.customColors
       .split(',')

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -29,7 +29,9 @@ module.exports = {
   prettifyObject,
   prettifyTime,
   buildSafeSonicBoom,
-  filterLog
+  filterLog,
+  handleCustomlevelsOpts,
+  handleCustomlevelNamesOpts
 }
 
 module.exports.internals = {
@@ -667,5 +669,66 @@ function autoEnd (stream, eventName) {
   } else {
     // We do not have an event loop, so flush synchronously
     stream.flushSync()
+  }
+}
+
+/**
+ * Returns a object which will be used to handle custom levels
+ *
+ * @param {string|object} cLevels Custom Levels can be object or string
+ *
+ * @returns {object} A object like level: level_name
+ */
+function handleCustomlevelsOpts (cLevels) {
+  if (!cLevels) return {}
+
+  if (typeof cLevels === 'string') {
+    return cLevels
+      .split(',')
+      .reduce((agg, value, idx) => {
+        const [levelName, levelIdx = idx] = value.split(':')
+        agg[levelIdx] = levelName.toUpperCase()
+        return agg
+      },
+      { default: 'USERLVL' })
+  } else if (typeof cLevels === 'object') {
+    return Object
+      .keys(cLevels)
+      .reduce((agg, levelName, idx) => {
+        agg[cLevels[levelName]] = levelName.toUpperCase()
+        return agg
+      }, { default: 'USERLVL' })
+  } else {
+    return {}
+  }
+}
+
+/**
+ * Returns a object which will be used to handle custom levels
+ *
+ * @param {string|object} cLevels Custom Levels can be object or string
+ *
+ * @returns {object} A object like level_name: level
+ */
+function handleCustomlevelNamesOpts (cLevels) {
+  if (!cLevels) return {}
+
+  if (typeof cLevels === 'string') {
+    return cLevels
+      .split(',')
+      .reduce((agg, value, idx) => {
+        const [levelName, levelIdx = idx] = value.split(':')
+        agg[levelName.toLowerCase()] = levelIdx
+        return agg
+      }, {})
+  } else if (typeof cLevels === 'object') {
+    return Object
+      .keys(cLevels)
+      .reduce((agg, levelName, idx) => {
+        agg[levelName.toLowerCase()] = cLevels[levelName]
+        return agg
+      }, {})
+  } else {
+    return {}
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -677,12 +677,12 @@ function autoEnd (stream, eventName) {
  * configuration for custom levels.
  *
  * @param {string|object} cLevels An object mapping level
- * names to his values, e.g. `{ info: 30, debug: 65 }`, or a
+ * names to values, e.g. `{ info: 30, debug: 65 }`, or a
  * CSV string in the format `level_name:level_value`, e.g.
  * `info:30,debug:65`.
  *
- * @returns {object} A object establishing labels to the levels that will apper in log
- * e.g. { '30': 'INFO', '65': 'DEBUG' }
+ * @returns {object} An object mapping levels to labels that
+ * appear in logs, e.g. `{ '30': 'INFO', '65': 'DEBUG' }`.
  */
 function handleCustomlevelsOpts (cLevels) {
   if (!cLevels) return {}
@@ -709,16 +709,16 @@ function handleCustomlevelsOpts (cLevels) {
 }
 
 /**
- * Parse a CSV string or options object that specifies
- * the level -> number_value relation.
+ * Parse a CSV string or options object that maps level
+ * labels to level values.
  *
  * @param {string|object} cLevels An object mapping level
- * names to his values, e.g. `{ info: 30, debug: 65 }`, or a
+ * names to level values, e.g. `{ info: 30, debug: 65 }`, or a
  * CSV string in the format `level_name:level_value`, e.g.
  * `info:30,debug:65`.
  *
- * @returns {object} A object establishing levels to the names of levels
- * e.g. { info: 30, debug: 65 }
+ * @returns {object} An object mapping levels names to level values
+ * e.g. `{ info: 30, debug: 65 }`.
  */
 function handleCustomlevelNamesOpts (cLevels) {
   if (!cLevels) return {}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -673,11 +673,16 @@ function autoEnd (stream, eventName) {
 }
 
 /**
- * Returns a object which will be used to handle custom levels
+ * Parse a CSV string or options object that specifies
+ * configuration for custom levels.
  *
- * @param {string|object} cLevels Custom Levels can be object or string
+ * @param {string|object} cLevels An object mapping level
+ * names to his values, e.g. `{ info: 30, debug: 65 }`, or a
+ * CSV string in the format `level_name:level_value`, e.g.
+ * `info:30,debug:65`.
  *
- * @returns {object} A object like level: level_name
+ * @returns {object} A object establishing labels to the levels that will apper in log
+ * e.g. { '30': 'INFO', '65': 'DEBUG' }
  */
 function handleCustomlevelsOpts (cLevels) {
   if (!cLevels) return {}
@@ -691,7 +696,7 @@ function handleCustomlevelsOpts (cLevels) {
         return agg
       },
       { default: 'USERLVL' })
-  } else if (typeof cLevels === 'object') {
+  } else if (Object.prototype.toString.call(cLevels) === '[object Object]') {
     return Object
       .keys(cLevels)
       .reduce((agg, levelName, idx) => {
@@ -704,11 +709,16 @@ function handleCustomlevelsOpts (cLevels) {
 }
 
 /**
- * Returns a object which will be used to handle custom levels
+ * Parse a CSV string or options object that specifies
+ * the level -> number_value relation.
  *
- * @param {string|object} cLevels Custom Levels can be object or string
+ * @param {string|object} cLevels An object mapping level
+ * names to his values, e.g. `{ info: 30, debug: 65 }`, or a
+ * CSV string in the format `level_name:level_value`, e.g.
+ * `info:30,debug:65`.
  *
- * @returns {object} A object like level_name: level
+ * @returns {object} A object establishing levels to the names of levels
+ * e.g. { info: 30, debug: 65 }
  */
 function handleCustomlevelNamesOpts (cLevels) {
   if (!cLevels) return {}
@@ -721,7 +731,7 @@ function handleCustomlevelNamesOpts (cLevels) {
         agg[levelName.toLowerCase()] = levelIdx
         return agg
       }, {})
-  } else if (typeof cLevels === 'object') {
+  } else if (Object.prototype.toString.call(cLevels) === '[object Object]') {
     return Object
       .keys(cLevels)
       .reduce((agg, levelName, idx) => {

--- a/test/lib/utils.public.test.js
+++ b/test/lib/utils.public.test.js
@@ -549,3 +549,71 @@ tap.test('buildSafeSonicBoom', t => {
 
   t.end()
 })
+
+tap.test('handleCustomlevelsOpts', t => {
+  const { handleCustomlevelsOpts } = utils
+
+  t.test('returns a empty object `{}` for unknown parameter', async t => {
+    const handledCustomLevel = handleCustomlevelsOpts(123)
+    t.same(handledCustomLevel, {})
+  })
+
+  t.test('returns a filled object for string parameter', async t => {
+    const handledCustomLevel = handleCustomlevelsOpts('ok:10,warn:20,error:35')
+    t.same(handledCustomLevel, {
+      10: 'OK',
+      20: 'WARN',
+      35: 'ERROR',
+      default: 'USERLVL'
+    })
+  })
+
+  t.test('returns a filled object for object parameter', async t => {
+    const handledCustomLevel = handleCustomlevelsOpts({
+      ok: 10,
+      warn: 20,
+      error: 35
+    })
+    t.same(handledCustomLevel, {
+      10: 'OK',
+      20: 'WARN',
+      35: 'ERROR',
+      default: 'USERLVL'
+    })
+  })
+
+  t.end()
+})
+
+tap.test('handleCustomlevelNamesOpts', t => {
+  const { handleCustomlevelNamesOpts } = utils
+
+  t.test('returns a empty object `{}` for unknown parameter', async t => {
+    const handledCustomLevelNames = handleCustomlevelNamesOpts(123)
+    t.same(handledCustomLevelNames, {})
+  })
+
+  t.test('returns a filled object for string parameter', async t => {
+    const handledCustomLevelNames = handleCustomlevelNamesOpts('ok:10,warn:20,error:35')
+    t.same(handledCustomLevelNames, {
+      ok: 10,
+      warn: 20,
+      error: 35
+    })
+  })
+
+  t.test('returns a filled object for object parameter', async t => {
+    const handledCustomLevelNames = handleCustomlevelNamesOpts({
+      ok: 10,
+      warn: 20,
+      error: 35
+    })
+    t.same(handledCustomLevelNames, {
+      ok: 10,
+      warn: 20,
+      error: 35
+    })
+  })
+
+  t.end()
+})


### PR DESCRIPTION
Hello, i made the changes to make possible pass in code as object or string the customLevels prop, it's still compatible with the CLI passing as string parameter.  I already wrote the tests too and keeps on the 100% coverage and asserted.

Is relative to #399 .