### PR TITLE
Add a colorizeObjects option to disable object colorization

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -57,6 +57,7 @@ node app.js | pino-pretty
 ### CLI Arguments
 
 - `--colorize` (`-c`): Adds terminal color escape sequences to the output.
+- `--colorizeObjects` (`-C`): Allows suppressing colorization of objects when set to `false`. In combination with `--singleLine`, this ensures that the end of each line is parsable JSON.
 - `--crlf` (`-f`): Appends carriage return and line feed, instead of just a line
   feed, to the formatted log line.
 - `--errorProps` (`-e`): When formatting an error object, display this list
@@ -235,6 +236,7 @@ The options accepted have keys corresponding to the options described in [CLI Ar
 ```js
 {
   colorize: colorette.isColorSupported, // --colorize
+  colorizeObjects: true, //--colorizeObjects
   crlf: false, // --crlf
   errorLikeObjectKeys: ['err', 'error'], // --errorLikeObjectKeys
   errorProps: '', // --errorProps

--- a/bin.js
+++ b/bin.js
@@ -40,6 +40,7 @@ const DEFAULT_VALUE = '\0default'
 let opts = minimist(process.argv, {
   alias: {
     colorize: 'c',
+    colorizeObjects: 'C',
     crlf: 'f',
     errorProps: 'e',
     levelFirst: 'l',

--- a/index.d.ts
+++ b/index.d.ts
@@ -108,6 +108,11 @@ interface PrettyOptions_ {
    */
   colorize?: boolean;
   /**
+   * If set to false while `colorize` is `true`, will output JSON objects without color.
+   * @default true
+   */
+  colorizeObjects?: boolean;
+  /**
    * Appends carriage return and line feed, instead of just a line feed, to the formatted log line.
    * @default false
    */

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ const jsonParser = input => {
 
 const defaultOptions = {
   colorize: isColorSupported,
+  colorizeObjects: true,
   crlf: false,
   errorLikeObjectKeys: ERROR_LIKE_KEYS,
   errorProps: '',
@@ -96,6 +97,7 @@ function prettyFactory (options) {
   const hideObject = opts.hideObject
   const singleLine = opts.singleLine
   const colorizer = colors(opts.colorize, customColors, useOnlyCustomProps)
+  const objectColorizer = opts.colorizeObjects ? colorizer : colors(false, [], false)
 
   return pretty
 
@@ -193,7 +195,7 @@ function prettyFactory (options) {
         eol: EOL,
         ident: IDENT,
         singleLine,
-        colorizer
+        colorizer: objectColorizer
       })
 
       // In single line mode, include a space only if prettified version isn't empty

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -82,6 +82,22 @@ test('basic prettifier tests', (t) => {
     log.info('foo')
   })
 
+  t.test('will omit color codes from objects when colorizeObjects = false', (t) => {
+    t.plan(1)
+    const pretty = prettyFactory({ colorize: true, singleLine: true, colorizeObjects: false })
+    const log = pino({}, new Writable({
+      write (chunk, enc, cb) {
+        const formatted = pretty(chunk.toString())
+        t.equal(
+          formatted,
+          `[${formattedEpoch}] \u001B[32mINFO\u001B[39m (${pid}): \u001B[36mfoo\u001B[39m {"foo":"bar"}\n`
+        )
+        cb()
+      }
+    }))
+    log.info({ foo: 'bar' }, 'foo')
+  })
+
   t.test('can swap date and level position', (t) => {
     t.plan(1)
     const destination = new Writable({


### PR DESCRIPTION
This allows log parsers that can detect JSON at the end of a log line to do so without being thrown off by ANSI colors.

Specifically, we're using Pino + Pino Pretty with Papertrail. Papertrail has [this feature](https://www.papertrail.com/help/json-search/) where they parse JSON at the end of a line. But their JSON parser fails to do so when that JSON is surrounded by ANSI codes.

I could disable colorization altogether, but Papertrail does nicely present ANSI colored logs in their web-UI, so I don't want to do that.

I've sent the Papertrail devs a message, because I think it'd be nicest if it were solved on their side, but as a plan B, and for the time being, this is the next best solution.