### PR TITLE
fix: node --disable-proto=throw compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "colorette": "^2.0.7",
     "dateformat": "^4.6.3",
-    "fast-copy": "^3.0.0",
+    "fast-copy": "^3.0.1",
     "fast-safe-stringify": "^2.1.1",
     "joycon": "^3.1.1",
     "help-me": "^4.0.1",


### PR DESCRIPTION
Bumps required (patch) version for `fast-copy` to ensure compatibility with NodeJS's `--disable-proto=throw` option (useful to mitigate prototype pollution attacks).

Reference: https://github.com/planttheidea/fast-copy/releases/tag/v3.0.1