### PR TITLE
Add customColors to typescript definition for PrettyOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -189,6 +189,16 @@ interface PrettyOptions_ {
    * @example ( Object ) customLevels: { info: 10, some_level: 40 }
    */
   customLevels?: string|object;
+  /**
+   * Change the level colors to an user custom preset.
+   *
+   * Can be a CSV string in 'level_name:color_value' format or an object.
+   * Also supports 'default' as level_name for fallback color.
+   *
+   * @example ( CSV ) customColors: 'info:white,some_level:red'
+   * @example ( Object ) customColors: { info: 'white', some_level: 'red' }
+   */
+  customColors?: string|object;
 }
 
 declare namespace PinoPretty {

--- a/test/types/pino-pretty.test-d.ts
+++ b/test/types/pino-pretty.test-d.ts
@@ -40,33 +40,6 @@ const options: PinoPretty.PrettyOptions = {
   mkdir: true,
 };
 
-const options2: PrettyOptions = {
-  colorize: true,
-  crlf: false,
-  errorLikeObjectKeys: ["err", "error"],
-  errorProps: "",
-  hideObject: true,
-  levelKey: "level",
-  levelLabel: "foo",
-  messageFormat: false,
-  ignore: "",
-  levelFirst: false,
-  messageKey: "msg",
-  timestampKey: "timestamp",
-  minimumLevel: "trace",
-  translateTime: "UTC:h:MM:ss TT Z",
-  singleLine: false,
-  customPrettifiers: {
-    key: (value) => {
-      return value.toString().toUpperCase();
-    }
-  },
-  sync: false,
-  destination: 2,
-  append: true,
-  mkdir: true,
-};
-
 expectType<PrettyStream>(pretty()); // #326
 expectType<PrettyStream>(pretty(options));
 expectType<PrettyStream>(PinoPrettyNamed(options));

--- a/test/types/pino-pretty.test-d.ts
+++ b/test/types/pino-pretty.test-d.ts
@@ -34,6 +34,8 @@ const options: PinoPretty.PrettyOptions = {
       return value.toString().toUpperCase();
     }
   },
+  customLevels: 'verbose:5',
+  customColors: 'default:white,verbose:gray',
   sync: false,
   destination: 2,
   append: true,

--- a/test/types/pino-pretty.test-d.ts
+++ b/test/types/pino-pretty.test-d.ts
@@ -76,5 +76,5 @@ expectType<PrettyStream>(PinoPrettyStar.default(options));
 expectType<PrettyStream>(PinoPrettyCjsImport.PinoPretty(options));
 expectType<PrettyStream>(PinoPrettyCjsImport.default(options));
 expectType<any>(PinoPrettyCjs(options));
-expectType<PinoPretty.ColorizerFactory>(colorizerFactory)
-expectType<PinoPretty.PrettyFactory>(prettyFactory)
+expectType<PinoPretty.ColorizerFactory>(colorizerFactory);
+expectType<PinoPretty.PrettyFactory>(prettyFactory);


### PR DESCRIPTION
See https://github.com/pinojs/pino-pretty/issues/439

Also contains minor cleanup of type test-file.

---

This assumes `index.d.ts` is managed manually and not autogenerated by some process as I didn't see any related script in `package.json`.

Also I've not worked with [TSD](https://github.com/SamVerschueren/tsd) so far, so I only added the missing example values for `customLevels` and `customColors` parameters to the options. 
A quick inverse check confirmed tests working as expected as they failed without adding `customColors` to the type definition. :+1: 