### PR TITLE
Add support for messageFormat strings containing conditionals

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -343,6 +343,14 @@ const levelPrettifier = logLevel => `LEVEL: ${levelColorize(logLevel)}`
 }
 ```
 
+In addition to this, if / end statement blocks can also be specified. Else statements and nested conditions are not supported.
+
+```js
+{
+  messageFormat: '{levelLabel} - {if pid}{pid}{end} - url:{req.url}'
+}
+```
+
 This option can also be defined as a `function` with this prototype:
 
 ```js

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -787,7 +787,7 @@ function handleCustomlevelNamesOpts (cLevels) {
 function parseMessageFormat (messageFormat, log) {
   messageFormat = messageFormat.replace(/{if (.*?)}(.*?){end}/g, function (_, key, value) {
     const propertyValue = getPropertyValue(log, key)
-    if (propertyValue) {
+    if (propertyValue && value.includes(key)) {
       return value.replace(new RegExp('{' + key + '}', 'g'), propertyValue)
     } else {
       return ''

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -263,16 +263,53 @@ function prettifyLevel ({ log, colorizer = defaultColorizer, levelKey = LEVEL_KE
  */
 function prettifyMessage ({ log, messageFormat, messageKey = MESSAGE_KEY, colorizer = defaultColorizer, levelLabel = LEVEL_LABEL, levelKey = LEVEL_KEY, customLevels, useOnlyCustomProps }) {
   if (messageFormat && typeof messageFormat === 'string') {
-    const message = String(messageFormat).replace(/{([^{}]+)}/g, function (match, p1) {
-      // return log level as string instead of int
-      let level
-      if (p1 === levelLabel && (level = getPropertyValue(log, levelKey)) !== undefined) {
-        const condition = useOnlyCustomProps ? customLevels === undefined : customLevels[level] === undefined
-        return condition ? LEVELS[level] : customLevels[level]
-      }
-      // Parse nested key access, e.g. `{keyA.subKeyB}`.
-      return getPropertyValue(log, p1) || ''
-    })
+    // console.log(
+    //   "pino-pretty | prettifyMessage | messageFormat: ",
+    //   messageFormat
+    // );
+    // console.log(
+    //   "pino-pretty | prettifyMessage | typeof messageFormat: ",
+    //   typeof messageFormat
+    // );
+    // console.log("pino-pretty | prettifyMessage | log: ", log);
+    // console.log("pino-pretty | prettifyMessage | typeof log: ", typeof log);
+
+    const parseMessageFormat = (input, log) => {
+      input = input.replace(/{if (.*?)}(.*?){end}/g, function (_, key, value) {
+        // console.log(`_: "${_}"`);
+        // console.log(`key: "${key}"`);
+        // console.log(`value: "${value}"`);
+        const propertyValue = getPropertyValue(log, key)
+        if (propertyValue) {
+          return value.replace(new RegExp('{' + key + '}', 'g'), propertyValue)
+        } else {
+          return ''
+        }
+      })
+
+      // console.log(`input: "${input}"`);
+      const replacedInput = input.replace(/\s+/g, ' ').trim()
+      // console.log(`replacedInput: "${replacedInput}"`);
+      return replacedInput
+    }
+
+    const parsedMessageFormat = parseMessageFormat(messageFormat, log)
+    // console.log("parsedMessageFormat", parsedMessageFormat);
+
+    const message = String(parsedMessageFormat).replace(
+      /{([^{}]+)}/g,
+      function (match, p1) {
+        // return log level as string instead of int
+        let level
+        if (p1 === levelLabel && (level = getPropertyValue(log, levelKey)) !== undefined) {
+          const condition = useOnlyCustomProps ? customLevels === undefined : customLevels[level] === undefined
+          return condition ? LEVELS[level] : customLevels[level]
+        }
+        // console.log('pino-pretty | prettifyMessage | p1: ', p1)
+
+        // Parse nested key access, e.g. `{keyA.subKeyB}`.
+        return getPropertyValue(log, p1) || ''
+      })
     return colorizer.message(message)
   }
   if (messageFormat && typeof messageFormat === 'function') {
@@ -383,7 +420,7 @@ function prettifyObject ({
   // Split object keys into two categories: error and non-error
   const { plain, errors } = Object.entries(input).reduce(({ plain, errors }, [k, v]) => {
     if (keysToIgnore.includes(k) === false) {
-      // Pre-apply custom prettifiers, because all 3 cases below will need this
+    // Pre-apply custom prettifiers, because all 3 cases below will need this
       const pretty = typeof customPrettifiers[k] === 'function'
         ? customPrettifiers[k](v, k, input)
         : v
@@ -557,7 +594,7 @@ function splitPropertyKey (key) {
  *
  * @param {object} obj The object to be searched.
  * @param {string|string[]} property A string, or an array of strings, identifying
-  * the property to be retrieved from the object.
+ * the property to be retrieved from the object.
  * Accepts nested properties delimited by a `.`.
  * Delimiter can be escaped to preserve property names that contain the delimiter.
  * e.g. `'prop1.prop2'` or `'prop2\.domain\.corp.prop2'`.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -43,7 +43,7 @@ module.exports.internals = {
   splitPropertyKey,
   createDate,
   isValidDate,
-  parseMessageFormat
+  interpretConditionals
 }
 
 /**
@@ -264,7 +264,7 @@ function prettifyLevel ({ log, colorizer = defaultColorizer, levelKey = LEVEL_KE
  */
 function prettifyMessage ({ log, messageFormat, messageKey = MESSAGE_KEY, colorizer = defaultColorizer, levelLabel = LEVEL_LABEL, levelKey = LEVEL_KEY, customLevels, useOnlyCustomProps }) {
   if (messageFormat && typeof messageFormat === 'string') {
-    const parsedMessageFormat = parseMessageFormat(messageFormat, log)
+    const parsedMessageFormat = interpretConditionals(messageFormat, log)
 
     const message = String(parsedMessageFormat).replace(
       /{([^{}]+)}/g,
@@ -784,15 +784,8 @@ function handleCustomlevelNamesOpts (cLevels) {
  *
  * @returns {string} The parsed messageFormat.
  */
-function parseMessageFormat (messageFormat, log) {
-  messageFormat = messageFormat.replace(/{if (.*?)}(.*?){end}/g, function (_, key, value) {
-    const propertyValue = getPropertyValue(log, key)
-    if (propertyValue && value.includes(key)) {
-      return value.replace(new RegExp('{' + key + '}', 'g'), propertyValue)
-    } else {
-      return ''
-    }
-  })
+function interpretConditionals (messageFormat, log) {
+  messageFormat = messageFormat.replace(/{if (.*?)}(.*?){end}/g, replacer)
 
   // Remove unescaped if blocks
   messageFormat = messageFormat.replace(/{if (.*?)}/g, '')
@@ -800,4 +793,13 @@ function parseMessageFormat (messageFormat, log) {
   messageFormat = messageFormat.replace(/{end}/g, '')
 
   return messageFormat.replace(/\s+/g, ' ').trim()
+
+  function replacer (_, key, value) {
+    const propertyValue = getPropertyValue(log, key)
+    if (propertyValue && value.includes(key)) {
+      return value.replace(new RegExp('{' + key + '}', 'g'), propertyValue)
+    } else {
+      return ''
+    }
+  }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -42,7 +42,8 @@ module.exports.internals = {
   deleteLogProperty,
   splitPropertyKey,
   createDate,
-  isValidDate
+  isValidDate,
+  parseMessageFormat
 }
 
 /**
@@ -263,38 +264,7 @@ function prettifyLevel ({ log, colorizer = defaultColorizer, levelKey = LEVEL_KE
  */
 function prettifyMessage ({ log, messageFormat, messageKey = MESSAGE_KEY, colorizer = defaultColorizer, levelLabel = LEVEL_LABEL, levelKey = LEVEL_KEY, customLevels, useOnlyCustomProps }) {
   if (messageFormat && typeof messageFormat === 'string') {
-    // console.log(
-    //   "pino-pretty | prettifyMessage | messageFormat: ",
-    //   messageFormat
-    // );
-    // console.log(
-    //   "pino-pretty | prettifyMessage | typeof messageFormat: ",
-    //   typeof messageFormat
-    // );
-    // console.log("pino-pretty | prettifyMessage | log: ", log);
-    // console.log("pino-pretty | prettifyMessage | typeof log: ", typeof log);
-
-    const parseMessageFormat = (input, log) => {
-      input = input.replace(/{if (.*?)}(.*?){end}/g, function (_, key, value) {
-        // console.log(`_: "${_}"`);
-        // console.log(`key: "${key}"`);
-        // console.log(`value: "${value}"`);
-        const propertyValue = getPropertyValue(log, key)
-        if (propertyValue) {
-          return value.replace(new RegExp('{' + key + '}', 'g'), propertyValue)
-        } else {
-          return ''
-        }
-      })
-
-      // console.log(`input: "${input}"`);
-      const replacedInput = input.replace(/\s+/g, ' ').trim()
-      // console.log(`replacedInput: "${replacedInput}"`);
-      return replacedInput
-    }
-
     const parsedMessageFormat = parseMessageFormat(messageFormat, log)
-    // console.log("parsedMessageFormat", parsedMessageFormat);
 
     const message = String(parsedMessageFormat).replace(
       /{([^{}]+)}/g,
@@ -305,7 +275,6 @@ function prettifyMessage ({ log, messageFormat, messageKey = MESSAGE_KEY, colori
           const condition = useOnlyCustomProps ? customLevels === undefined : customLevels[level] === undefined
           return condition ? LEVELS[level] : customLevels[level]
         }
-        // console.log('pino-pretty | prettifyMessage | p1: ', p1)
 
         // Parse nested key access, e.g. `{keyA.subKeyB}`.
         return getPropertyValue(log, p1) || ''
@@ -802,4 +771,33 @@ function handleCustomlevelNamesOpts (cLevels) {
   } else {
     return {}
   }
+}
+
+/**
+ * Translates all conditional blocks from within the messageFormat. Translates any matching
+ * {if key}{key}{end} statements and returns everything between if and else blocks if the key provided
+ * was found in log.
+ *
+ * @param {string} messageFormat A format string or function that defines how the
+ *  logged message should be conditionally formatted, e.g. `'{if level}{level}{end} - {if req.id}{req.id}{end}'`.
+ * @param {object} log The log object to be modified.
+ *
+ * @returns {string} The parsed messageFormat.
+ */
+function parseMessageFormat (messageFormat, log) {
+  messageFormat = messageFormat.replace(/{if (.*?)}(.*?){end}/g, function (_, key, value) {
+    const propertyValue = getPropertyValue(log, key)
+    if (propertyValue) {
+      return value.replace(new RegExp('{' + key + '}', 'g'), propertyValue)
+    } else {
+      return ''
+    }
+  })
+
+  // Remove unescaped if blocks
+  messageFormat = messageFormat.replace(/{if (.*?)}/g, '')
+  // Remove unescaped end blocks
+  messageFormat = messageFormat.replace(/{end}/g, '')
+
+  return messageFormat.replace(/\s+/g, ' ').trim()
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -787,9 +787,9 @@ function handleCustomlevelNamesOpts (cLevels) {
 function interpretConditionals (messageFormat, log) {
   messageFormat = messageFormat.replace(/{if (.*?)}(.*?){end}/g, replacer)
 
-  // Remove unescaped if blocks
+  // Remove non-terminated if blocks
   messageFormat = messageFormat.replace(/{if (.*?)}/g, '')
-  // Remove unescaped end blocks
+  // Remove floating end blocks
   messageFormat = messageFormat.replace(/{end}/g, '')
 
   return messageFormat.replace(/\s+/g, ' ').trim()

--- a/test/lib/utils.internals.test.js
+++ b/test/lib/utils.internals.test.js
@@ -223,7 +223,7 @@ tap.test('#getPropertyValue', t => {
   t.end()
 })
 
-tap.test('#parseMessageFormat', t => {
+tap.test('#interpretConditionals', t => {
   const logData = {
     level: 30,
     data1: {
@@ -232,54 +232,59 @@ tap.test('#parseMessageFormat', t => {
     msg: 'foo'
   }
 
-  t.test('parseMessageFormat translates if / else statement to found property value', async t => {
+  t.test('interpretConditionals translates if / else statement to found property value', async t => {
     const log = fastCopy(logData)
-    t.equal(internals.parseMessageFormat('{level} - {if data1.data2}{data1.data2}{end}', log), '{level} - bar')
+    t.equal(internals.interpretConditionals('{level} - {if data1.data2}{data1.data2}{end}', log), '{level} - bar')
   })
 
-  t.test('parseMessageFormat translates if / else statement to found property value and leave unmatched property key untouched', async t => {
+  t.test('interpretConditionals translates if / else statement to found property value and leave unmatched property key untouched', async t => {
     const log = fastCopy(logData)
-    t.equal(internals.parseMessageFormat('{level} - {if data1.data2}{data1.data2} ({msg}){end}', log), '{level} - bar ({msg})')
+    t.equal(internals.interpretConditionals('{level} - {if data1.data2}{data1.data2} ({msg}){end}', log), '{level} - bar ({msg})')
   })
 
-  t.test('parseMessageFormat removes unescaped if statements', async t => {
+  t.test('interpretConditionals removes non-terminated if statements', async t => {
     const log = fastCopy(logData)
-    t.equal(internals.parseMessageFormat('{level} - {if data1.data2}{data1.data2}', log), '{level} - {data1.data2}')
+    t.equal(internals.interpretConditionals('{level} - {if data1.data2}{data1.data2}', log), '{level} - {data1.data2}')
   })
 
-  t.test('parseMessageFormat removes unescaped end statements', async t => {
+  t.test('interpretConditionals removes floating end statements', async t => {
     const log = fastCopy(logData)
-    t.equal(internals.parseMessageFormat('{level} - {data1.data2}{end}', log), '{level} - {data1.data2}')
+    t.equal(internals.interpretConditionals('{level} - {data1.data2}{end}', log), '{level} - {data1.data2}')
   })
 
-  t.test('parseMessageFormat removes if / end blocks if existent condition key does not match existent property key', async t => {
+  t.test('interpretConditionals removes floating end statements within translated if / end statements', async t => {
     const log = fastCopy(logData)
-    t.equal(internals.parseMessageFormat('{level}{if msg}{data1.data2}{end}', log), '{level}')
+    t.equal(internals.interpretConditionals('{level} - {if msg}({msg}){end}{end}', log), '{level} - (foo)')
   })
 
-  t.test('parseMessageFormat removes if / end blocks if non-existent condition key does not match existent property key', async t => {
+  t.test('interpretConditionals removes if / end blocks if existent condition key does not match existent property key', async t => {
     const log = fastCopy(logData)
-    t.equal(internals.parseMessageFormat('{level}{if foo}{msg}{end}', log), '{level}')
+    t.equal(internals.interpretConditionals('{level}{if msg}{data1.data2}{end}', log), '{level}')
   })
 
-  t.test('parseMessageFormat removes if / end blocks if existent condition key does not match non-existent property key', async t => {
+  t.test('interpretConditionals removes if / end blocks if non-existent condition key does not match existent property key', async t => {
     const log = fastCopy(logData)
-    t.equal(internals.parseMessageFormat('{level}{if msg}{foo}{end}', log), '{level}')
+    t.equal(internals.interpretConditionals('{level}{if foo}{msg}{end}', log), '{level}')
   })
 
-  t.test('parseMessageFormat removes if / end blocks if non-existent condition key does not match non-existent property key', async t => {
+  t.test('interpretConditionals removes if / end blocks if existent condition key does not match non-existent property key', async t => {
     const log = fastCopy(logData)
-    t.equal(internals.parseMessageFormat('{level}{if foo}{bar}{end}', log), '{level}')
+    t.equal(internals.interpretConditionals('{level}{if msg}{foo}{end}', log), '{level}')
   })
 
-  t.test('parseMessageFormat removes if / end blocks if nested condition key does not match property key', async t => {
+  t.test('interpretConditionals removes if / end blocks if non-existent condition key does not match non-existent property key', async t => {
     const log = fastCopy(logData)
-    t.equal(internals.parseMessageFormat('{level}{if data1.msg}{data1.data2}{end}', log), '{level}')
+    t.equal(internals.interpretConditionals('{level}{if foo}{bar}{end}', log), '{level}')
   })
 
-  t.test('parseMessageFormat removes nested if / end statement blocks', async t => {
+  t.test('interpretConditionals removes if / end blocks if nested condition key does not match property key', async t => {
     const log = fastCopy(logData)
-    t.equal(internals.parseMessageFormat('{if msg}{if data1.data2}{msg}{data1.data2}{end}{end}', log), 'foo{data1.data2}')
+    t.equal(internals.interpretConditionals('{level}{if data1.msg}{data1.data2}{end}', log), '{level}')
+  })
+
+  t.test('interpretConditionals removes nested if / end statement blocks', async t => {
+    const log = fastCopy(logData)
+    t.equal(internals.interpretConditionals('{if msg}{if data1.data2}{msg}{data1.data2}{end}{end}', log), 'foo{data1.data2}')
   })
 
   t.end()

--- a/test/lib/utils.internals.test.js
+++ b/test/lib/utils.internals.test.js
@@ -228,12 +228,18 @@ tap.test('#parseMessageFormat', t => {
     level: 30,
     data1: {
       data2: 'bar'
-    }
+    },
+    msg: 'foo'
   }
 
   t.test('parseMessageFormat translates if / else statement to found property value', async t => {
     const log = fastCopy(logData)
     t.equal(internals.parseMessageFormat('{level} - {if data1.data2}{data1.data2}{end}', log), '{level} - bar')
+  })
+
+  t.test('parseMessageFormat translates if / else statement to found property value and leave unmatched property key untouched', async t => {
+    const log = fastCopy(logData)
+    t.equal(internals.parseMessageFormat('{level} - {if data1.data2}{data1.data2} ({msg}){end}', log), '{level} - bar ({msg})')
   })
 
   t.test('parseMessageFormat removes unescaped if statements', async t => {
@@ -244,6 +250,36 @@ tap.test('#parseMessageFormat', t => {
   t.test('parseMessageFormat removes unescaped end statements', async t => {
     const log = fastCopy(logData)
     t.equal(internals.parseMessageFormat('{level} - {data1.data2}{end}', log), '{level} - {data1.data2}')
+  })
+
+  t.test('parseMessageFormat removes if / end blocks if existent condition key does not match existent property key', async t => {
+    const log = fastCopy(logData)
+    t.equal(internals.parseMessageFormat('{level}{if msg}{data1.data2}{end}', log), '{level}')
+  })
+
+  t.test('parseMessageFormat removes if / end blocks if non-existent condition key does not match existent property key', async t => {
+    const log = fastCopy(logData)
+    t.equal(internals.parseMessageFormat('{level}{if foo}{msg}{end}', log), '{level}')
+  })
+
+  t.test('parseMessageFormat removes if / end blocks if existent condition key does not match non-existent property key', async t => {
+    const log = fastCopy(logData)
+    t.equal(internals.parseMessageFormat('{level}{if msg}{foo}{end}', log), '{level}')
+  })
+
+  t.test('parseMessageFormat removes if / end blocks if non-existent condition key does not match non-existent property key', async t => {
+    const log = fastCopy(logData)
+    t.equal(internals.parseMessageFormat('{level}{if foo}{bar}{end}', log), '{level}')
+  })
+
+  t.test('parseMessageFormat removes if / end blocks if nested condition key does not match property key', async t => {
+    const log = fastCopy(logData)
+    t.equal(internals.parseMessageFormat('{level}{if data1.msg}{data1.data2}{end}', log), '{level}')
+  })
+
+  t.test('parseMessageFormat removes nested if / end statement blocks', async t => {
+    const log = fastCopy(logData)
+    t.equal(internals.parseMessageFormat('{if msg}{if data1.data2}{msg}{data1.data2}{end}{end}', log), 'foo{data1.data2}')
   })
 
   t.end()

--- a/test/lib/utils.internals.test.js
+++ b/test/lib/utils.internals.test.js
@@ -222,3 +222,29 @@ tap.test('#getPropertyValue', t => {
 
   t.end()
 })
+
+tap.test('#parseMessageFormat', t => {
+  const logData = {
+    level: 30,
+    data1: {
+      data2: 'bar'
+    }
+  }
+
+  t.test('parseMessageFormat translates if / else statement to found property value', async t => {
+    const log = fastCopy(logData)
+    t.equal(internals.parseMessageFormat('{level} - {if data1.data2}{data1.data2}{end}', log), '{level} - bar')
+  })
+
+  t.test('parseMessageFormat removes unescaped if statements', async t => {
+    const log = fastCopy(logData)
+    t.equal(internals.parseMessageFormat('{level} - {if data1.data2}{data1.data2}', log), '{level} - {data1.data2}')
+  })
+
+  t.test('parseMessageFormat removes unescaped end statements', async t => {
+    const log = fastCopy(logData)
+    t.equal(internals.parseMessageFormat('{level} - {data1.data2}{end}', log), '{level} - {data1.data2}')
+  })
+
+  t.end()
+})

--- a/test/lib/utils.public.test.js
+++ b/test/lib/utils.public.test.js
@@ -141,6 +141,11 @@ tap.test('prettifyMessage', t => {
     t.equal(str, 'localhost/test - param:  - foo')
   })
 
+  t.test('`messageFormat` supports conditional blocks', async t => {
+    const str = prettifyMessage({ log: { level: 30, req: { id: 'foo' } }, messageFormat: '{level} | {if req.id}({req.id}){end}{if msg}{msg}{end}' })
+    t.equal(str, '30 | (foo)')
+  })
+
   t.test('`messageFormat` supports function definition', async t => {
     const str = prettifyMessage({
       log: { level: 30, request: { url: 'localhost/test' }, msg: 'incoming request' },


### PR DESCRIPTION
See [#441](https://github.com/pinojs/pino-pretty/issues/441)
---
It's now possible to pass `--messageFormat` option containing conditional statements for log data.

Example log data:
`{level: 30, req: {id: 'foo'}}`

Example `--messageFormat` containing conditional:
`"{level} - {if req.id}({req.id}){end}{if msg} - {msg}{end}"`

Example output:
`"30 - (foo)"`

Unescaped if / end block  within `--messageFormat` will just be deleted.