### PR TITLE
Add basic benchmark suite

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1,0 +1,105 @@
+'use strict'
+
+// We do not expect amazing numbers from `pino-pretty` as the whole purpose
+// of the module is a very slow operation. However, this benchmark should give
+// us some guidance on how features, or code changes, will affect the
+// performance of the module.
+
+const bench = require('fastbench')
+const {
+  prettyFactory
+} = require('./index')
+
+const max = 10
+const tstampMillis = 1693401358754
+
+/* eslint-disable no-var */
+const run = bench([
+  function basicLog (cb) {
+    const pretty = prettyFactory({})
+    const input = `{"time":${tstampMillis},"pid":1,"hostname":"foo","msg":"benchmark","foo":"foo","bar":{"bar":"bar"}}\n`
+    for (var i = 0; i < max; i += 1) {
+      pretty(input)
+    }
+    setImmediate(cb)
+  },
+
+  function objectLog (cb) {
+    const pretty = prettyFactory({})
+    const input = {
+      time: tstampMillis,
+      pid: 1,
+      hostname: 'foo',
+      msg: 'benchmark',
+      foo: 'foo',
+      bar: { bar: 'bar' }
+    }
+    for (var i = 0; i < max; i += 1) {
+      pretty(input)
+    }
+    setImmediate(cb)
+  },
+
+  function coloredLog (cb) {
+    const pretty = prettyFactory({ colorize: true })
+    const input = `{"time":${tstampMillis},"pid":1,"hostname":"foo","msg":"benchmark","foo":"foo","bar":{"bar":"bar"}}\n`
+    for (var i = 0; i < max; i += 1) {
+      pretty(input)
+    }
+    setImmediate(cb)
+  },
+
+  function customPrettifiers (cb) {
+    const pretty = prettyFactory({
+      customPrettifiers: {
+        time (tstamp) {
+          return tstamp
+        },
+        pid () {
+          return ''
+        }
+      }
+    })
+    const input = `{"time":${tstampMillis},"pid":1,"hostname":"foo","msg":"benchmark","foo":"foo","bar":{"bar":"bar"}}\n`
+    for (var i = 0; i < max; i += 1) {
+      pretty(input)
+    }
+    setImmediate(cb)
+  },
+
+  function logWithErrorObject (cb) {
+    const pretty = prettyFactory({})
+    const err = Error('boom')
+    const input = `{"time":${tstampMillis},"pid":1,"hostname":"foo","msg":"benchmark","foo":"foo","bar":{"bar":"bar"},"err":{"message":"${err.message}","stack":"${err.stack}"}}\n`
+    for (var i = 0; i < max; i += 1) {
+      pretty(input)
+    }
+    setImmediate(cb)
+  },
+
+  function logRemappedMsgErrKeys (cb) {
+    const pretty = prettyFactory({
+      messageKey: 'message',
+      errorLikeObjectKeys: ['myError']
+    })
+    const err = Error('boom')
+    const input = `{"time":${tstampMillis},"pid":1,"hostname":"foo","message":"benchmark","foo":"foo","bar":{"bar":"bar"},"myError":{"message":"${err.message}","stack":"${err.stack}"}}\n`
+    for (var i = 0; i < max; i += 1) {
+      pretty(input)
+    }
+    setImmediate(cb)
+  },
+
+  function messageFormatString (cb) {
+    const pretty = prettyFactory({
+      messageFormat: '{levelLabel}{if pid} {pid} - {end}{msg}'
+    })
+    const input = `{"time":${tstampMillis},"pid":1,"hostname":"foo","msg":"benchmark","foo":"foo","bar":{"bar":"bar"}}\n`
+    for (var i = 0; i < max; i += 1) {
+      pretty(input)
+    }
+    setImmediate(cb)
+  }
+], 10000)
+
+run(run)

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "dateformat": "^4.6.3",
     "fast-copy": "^3.0.0",
     "fast-safe-stringify": "^2.1.1",
-    "joycon": "^3.1.1",
     "help-me": "^4.0.1",
+    "joycon": "^3.1.1",
     "minimist": "^1.2.6",
     "on-exit-leak-free": "^2.1.0",
     "pino-abstract-transport": "^1.0.0",
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.1.0",
+    "fastbench": "^1.0.1",
     "pino": "^8.0.0",
     "pre-commit": "^1.2.2",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
As noted in the script, we don't really care about these numbers, but they should help us understand how features affect performance.

On my M1, using 18.17.1, I get:

```
basicLog*10000: 776.762ms
objectLog*10000: 656.023ms
coloredLog*10000: 729.25ms
customPrettifiers*10000: 740.291ms
logWithErrorObject*10000: 564.892ms
logRemappedMsgErrKeys*10000: 580.711ms
messageFormatString*10000: 945.966ms
basicLog*10000: 727.929ms
objectLog*10000: 654.281ms
coloredLog*10000: 736.466ms
customPrettifiers*10000: 724.02ms
logWithErrorObject*10000: 556.315ms
logRemappedMsgErrKeys*10000: 558.546ms
messageFormatString*10000: 918.586ms
```