### PR TITLE
fix: exclude files from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,10 @@
+/.github/
+/docs/
+/help/
+/test/
+.taprc.yaml
+/benchmark.js
+/coverage-map.js
+/tsconfig.json
+
+*.test.js


### PR DESCRIPTION
Those files shouldn't be inside the npm package. Otherwise they can cause side effects.

https://github.com/containerbase/base/actions/runs/6480142703/job/17595082781?pr=1562