### PR TITLE
chore: Remove `config` from README programmatic usage options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -252,7 +252,6 @@ The options accepted have keys corresponding to the options described in [CLI Ar
   include: 'level,time', // --include
   hideObject: false, // --hideObject
   singleLine: false, // --singleLine
-  config: '/path/to/config/', // --config
   customColors: 'err:red,info:blue', // --customColors
   customLevels: 'err:99,info:1', // --customLevels
   levelLabel: 'levelLabel', // --levelLabel


### PR DESCRIPTION
Removes the `config` option from the README's programmatic options. The `config` option is only relevant to CLI usage.

A possible related enhancement could be to error for any "unknown" options (for example, passing `config` for programmatic usage is silently ignored at the moment).

Resolves https://github.com/pinojs/pino-pretty/issues/429