### PR TITLE
Support objects in options.customColors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,6 @@ profile-*
 
 # Run Configuration
 test/.tmp*
+
+# Local History
+.history

--- a/lib/utils/parse-factory-options.js
+++ b/lib/utils/parse-factory-options.js
@@ -87,23 +87,39 @@ function parseFactoryOptions (options) {
 
   let customColors
   if (options.customColors) {
-    customColors = options.customColors.split(',').reduce((agg, value) => {
-      const [level, color] = value.split(':')
-
-      const condition = useOnlyCustomProps
-        ? options.customLevels
-        : customLevelNames[level] !== undefined
-      const levelNum = condition
-        ? customLevelNames[level]
-        : LEVEL_NAMES[level]
-      const colorIdx = levelNum !== undefined
-        ? levelNum
-        : level
-
-      agg.push([colorIdx, color])
-
-      return agg
-    }, [])
+    if (typeof options.customColors === 'string') {
+      customColors = options.customColors.split(',').reduce((agg, value) => {
+        const [level, color] = value.split(':')
+        const condition = useOnlyCustomProps
+          ? options.customLevels
+          : customLevelNames[level] !== undefined
+        const levelNum = condition
+          ? customLevelNames[level]
+          : LEVEL_NAMES[level]
+        const colorIdx = levelNum !== undefined
+          ? levelNum
+          : level
+        agg.push([colorIdx, color])
+        return agg
+      }, [])
+    } else if(typeof options.customColors === 'object') {
+      customColors = Object.keys(options.customColors).reduce((agg, value) => {
+        const [level, color] = [value, options.customColors[value]]
+        const condition = useOnlyCustomProps
+          ? options.customLevels
+          : customLevelNames[level] !== undefined
+        const levelNum = condition
+          ? customLevelNames[level]
+          : LEVEL_NAMES[level]
+        const colorIdx = levelNum !== undefined
+          ? levelNum
+          : level
+        agg.push([colorIdx, color])
+        return agg
+      }, [])
+    } else {
+      throw new Error(`customColors must be of type string or object.`)
+    }
   }
 
   const customProperties = { customLevels, customLevelNames }

--- a/lib/utils/parse-factory-options.js
+++ b/lib/utils/parse-factory-options.js
@@ -102,7 +102,7 @@ function parseFactoryOptions (options) {
         agg.push([colorIdx, color])
         return agg
       }, [])
-    } else if(typeof options.customColors === 'object') {
+    } else if (typeof options.customColors === 'object') {
       customColors = Object.keys(options.customColors).reduce((agg, value) => {
         const [level, color] = [value, options.customColors[value]]
         const condition = useOnlyCustomProps
@@ -118,7 +118,7 @@ function parseFactoryOptions (options) {
         return agg
       }, [])
     } else {
-      throw new Error(`options.customColors must be of type string or object.`)
+      throw new Error('options.customColors must be of type string or object.')
     }
   }
 

--- a/lib/utils/parse-factory-options.js
+++ b/lib/utils/parse-factory-options.js
@@ -118,7 +118,7 @@ function parseFactoryOptions (options) {
         return agg
       }, [])
     } else {
-      throw new Error(`customColors must be of type string or object.`)
+      throw new Error(`options.customColors must be of type string or object.`)
     }
   }
 

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1061,6 +1061,32 @@ test('basic prettifier tests', (t) => {
     t.equal(formatted, `[${formattedEpoch}] INFO (${pid}): message {"extra":{"foo":"bar","number":42},"upper":"foobar"}\n`)
   })
 
+  t.test('support custom colors object', async (t) => {
+    t.plan(1)
+    const pretty = prettyFactory({
+      colorize: true,
+      customColors: {
+        trace: 'cyan',
+        debug: 'blue',
+        info: 'green',
+        warn: 'yellow',
+        error: 'red',
+        fatal: 'red'
+      }
+    })
+    const log = pino({}, new Writable({
+      write (chunk, enc, cb) {
+        const formatted = pretty(chunk.toString())
+        t.equal(
+          formatted,
+          `[${formattedEpoch}] \u001B[32mINFO\u001B[39m (${pid}): \u001B[36mfoo\u001B[39m\n`
+        )
+        cb()
+      }
+    }))
+    log.info('foo')
+  })
+
   t.end()
 })
 


### PR DESCRIPTION
Documentation notes that options.customColors can be either a string or object but objects are not currently supported in the code.
From index.d.ts:
  /**
   * Change the level colors to an user custom preset.
   *
   * Can be a CSV string in 'level_name:color_value' format or an object.
   * Also supports 'default' as level_name for fallback color.
   *
   * @example ( CSV ) customColors: 'info:white,some_level:red'
   * @example ( Object ) customColors: { info: 'white', some_level: 'red' }
   */
  customColors?: string|object;

This change permits either strings or objects to be used.