### PR TITLE
Providing additional functionality to customPrettifiers and messageFormat

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -311,6 +311,9 @@ Additionally, `customPrettifiers` can be used to format the `time`, `hostname`,
     // on if the levelKey option is used or not.
     // By default this will be the same numerics as the Pino default:
     level: logLevel => `LEVEL: ${logLevel}`,
+    // Additionally, optional second and third arguments arguments can be provided
+    // to get the level label as a string and the colorized version (if `colorize: true`), respectively:
+    level: (logLevel, levelLabel, coloredLevelLabel) => `LEVEL: ${logLevel} LABEL: ${levelLabel} COLORIZED LABEL: ${coloredLevelLabel}`,
 
     // other prettifiers can be used for the other keys if needed, for example
     hostname: hostname => colorGreen(hostname),
@@ -321,18 +324,7 @@ Additionally, `customPrettifiers` can be used to format the `time`, `hostname`,
 }
 ```
 
-Note that prettifiers do not include any coloring, if the stock coloring on
-`level` is desired, it can be accomplished using the following:
-
-```js
-const { colorizerFactory } = require('pino-pretty')
-const levelColorize = colorizerFactory(true)
-const levelPrettifier = logLevel => `LEVEL: ${levelColorize(logLevel)}`
-//...
-{
-  customPrettifiers: { level: levelPrettifier }
-}
-```
+Note that prettifiers, other than `level`, do not include any coloring.
 
 `messageFormat` option allows you to customize the message output.
 A template `string` like this can define the format:

--- a/Readme.md
+++ b/Readme.md
@@ -348,9 +348,11 @@ This option can also be defined as a `function` with this prototype:
 
 ```js
 {
-  messageFormat: (log, messageKey, levelLabel) => {
+  messageFormat: (log, messageKey, levelLabel, { colors }) => {
     // do some log message customization
-    return customized_message;
+    //
+    // `colors` is a Colorette object with colors enabled based on `colorize` option
+    return `This is a ${color.red('colorized')}, custom message: ${log[messageKey]}`;
   }
 }
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,7 @@ import { Transform } from 'stream';
 import { OnUnknown } from 'pino-abstract-transport';
 // @ts-ignore fall back to any if pino is not available, i.e. when running pino tests
 import { DestinationStream, Level } from 'pino';
+import LevelPrettifierExtras = PinoPretty.LevelPrettifierExtras;
 
 type LogDescriptor = Record<string, unknown>;
 
@@ -179,7 +180,10 @@ interface PrettyOptions_ {
    * }
    * ```
    */
-  customPrettifiers?: Record<string, PinoPretty.Prettifier>;
+  customPrettifiers?: Record<string, PinoPretty.Prettifier> &
+    {
+      level?: PinoPretty.Prettifier<PinoPretty.LevelPrettifierExtras>
+    };
   /**
    * Change the level names and values to an user custom preset.
    *
@@ -204,7 +208,9 @@ interface PrettyOptions_ {
 declare function build(options: PrettyOptions_): PinoPretty.PrettyStream;
 
 declare namespace PinoPretty {
-  type Prettifier = (inputData: string | object) => string;
+  type Prettifier<T = object> = (inputData: string | object, extras: PrettifierExtras<T>) => string;
+  type PrettifierExtras<T = object> = object & T;
+  type LevelPrettifierExtras = {label: string, labelColorized: string}
   type MessageFormatFunc = (log: LogDescriptor, messageKey: string, levelLabel: string) => string;
   type PrettyOptions = PrettyOptions_;
   type PrettyStream = Transform & OnUnknown;

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,7 @@ import { OnUnknown } from 'pino-abstract-transport';
 // @ts-ignore fall back to any if pino is not available, i.e. when running pino tests
 import { DestinationStream, Level } from 'pino';
 import LevelPrettifierExtras = PinoPretty.LevelPrettifierExtras;
+import * as Colorette from "colorette";
 
 type LogDescriptor = Record<string, unknown>;
 
@@ -208,10 +209,10 @@ interface PrettyOptions_ {
 declare function build(options: PrettyOptions_): PinoPretty.PrettyStream;
 
 declare namespace PinoPretty {
-  type Prettifier<T = object> = (inputData: string | object, extras: PrettifierExtras<T>) => string;
-  type PrettifierExtras<T = object> = object & T;
+  type Prettifier<T = object> = (inputData: string | object, key: string, log: object, extras: PrettifierExtras<T>) => string;
+  type PrettifierExtras<T = object> = {colors: Colorette.Colorette} & T;
   type LevelPrettifierExtras = {label: string, labelColorized: string}
-  type MessageFormatFunc = (log: LogDescriptor, messageKey: string, levelLabel: string) => string;
+  type MessageFormatFunc = (log: LogDescriptor, messageKey: string, levelLabel: string, extras: PrettifierExtras) => string;
   type PrettyOptions = PrettyOptions_;
   type PrettyStream = Transform & OnUnknown;
   type ColorizerFactory = typeof colorizerFactory;

--- a/lib/colors.js
+++ b/lib/colors.js
@@ -56,6 +56,7 @@ function plainColorizer (useOnlyCustomProps) {
   }
   customColoredColorizer.message = plain.message
   customColoredColorizer.greyMessage = plain.greyMessage
+  customColoredColorizer.colors = createColors({ useColor: false })
   return customColoredColorizer
 }
 
@@ -66,6 +67,7 @@ function coloredColorizer (useOnlyCustomProps) {
   }
   customColoredColorizer.message = colored.message
   customColoredColorizer.greyMessage = colored.greyMessage
+  customColoredColorizer.colors = availableColors
   return customColoredColorizer
 }
 
@@ -94,6 +96,7 @@ function customColoredColorizerFactory (customColors, useOnlyCustomProps) {
  * recognized.
  * @property {function} message Accepts one string parameter that will be
  * colorized to a predefined color.
+ * @property {Colorette.Colorette} colors Available color functions based on `useColor` (or `colorize`) context
  */
 
 /**

--- a/lib/colors.js
+++ b/lib/colors.js
@@ -79,6 +79,7 @@ function customColoredColorizerFactory (customColors, useOnlyCustomProps) {
   const customColoredColorizer = function (level, opts) {
     return colorizeLevelCustom(level, customColored, opts)
   }
+  customColoredColorizer.colors = availableColors
   customColoredColorizer.message = customColoredColorizer.message || customColored.message
   customColoredColorizer.greyMessage = customColoredColorizer.greyMessage || customColored.greyMessage
 

--- a/lib/colors.js
+++ b/lib/colors.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const { LEVELS, LEVEL_NAMES } = require('./constants')
-
 const nocolor = input => input
 const plain = {
   default: nocolor,
@@ -16,6 +14,7 @@ const plain = {
 }
 
 const { createColors } = require('colorette')
+const getLevelLabelData = require('./utils/get-level-label-data')
 const availableColors = createColors({ useColor: true })
 const { white, bgRed, red, yellow, green, blue, gray, cyan } = availableColors
 
@@ -44,17 +43,7 @@ function resolveCustomColoredColorizer (customColors) {
 
 function colorizeLevel (useOnlyCustomProps) {
   return function (level, colorizer, { customLevels, customLevelNames } = {}) {
-    const levels = useOnlyCustomProps ? customLevels || LEVELS : Object.assign({}, LEVELS, customLevels)
-    const levelNames = useOnlyCustomProps ? customLevelNames || LEVEL_NAMES : Object.assign({}, LEVEL_NAMES, customLevelNames)
-
-    let levelNum = 'default'
-    if (Number.isInteger(+level)) {
-      levelNum = Object.prototype.hasOwnProperty.call(levels, level) ? level : levelNum
-    } else {
-      levelNum = Object.prototype.hasOwnProperty.call(levelNames, level.toLowerCase()) ? levelNames[level.toLowerCase()] : levelNum
-    }
-
-    const levelStr = levels[levelNum]
+    const [levelStr, levelNum] = getLevelLabelData(useOnlyCustomProps, customLevels, customLevelNames)(level)
 
     return Object.prototype.hasOwnProperty.call(colorizer, levelNum) ? colorizer[levelNum](levelStr) : colorizer.default(levelStr)
   }

--- a/lib/utils/get-level-label-data.js
+++ b/lib/utils/get-level-label-data.js
@@ -1,0 +1,29 @@
+'use strict'
+
+module.exports = getLevelLabelData
+const { LEVELS, LEVEL_NAMES } = require('../constants')
+
+/**
+ * Given initial settings for custom levels/names and use of only custom props
+ * get the level label that corresponds with a given level number
+ *
+ * @param {boolean} useOnlyCustomProps
+ * @param {object} customLevels
+ * @param {object} customLevelNames
+ *
+ * @returns {function} A function that takes a number level and returns the level's label string
+ */
+function getLevelLabelData (useOnlyCustomProps, customLevels, customLevelNames) {
+  const levels = useOnlyCustomProps ? customLevels || LEVELS : Object.assign({}, LEVELS, customLevels)
+  const levelNames = useOnlyCustomProps ? customLevelNames || LEVEL_NAMES : Object.assign({}, LEVEL_NAMES, customLevelNames)
+  return function (level) {
+    let levelNum = 'default'
+    if (Number.isInteger(+level)) {
+      levelNum = Object.prototype.hasOwnProperty.call(levels, level) ? level : levelNum
+    } else {
+      levelNum = Object.prototype.hasOwnProperty.call(levelNames, level.toLowerCase()) ? levelNames[level.toLowerCase()] : levelNum
+    }
+
+    return [levels[levelNum], levelNum]
+  }
+}

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -80,6 +80,12 @@ module.exports = {
  */
 
 /**
+ * @typedef {object} PrettifyMessageExtras
+ * @property {object} colors Available color functions based on `useColor` (or `colorize`) context
+ * the options.
+ */
+
+/**
  * A function that accepts a log object, name of the message key, and name of
  * the level label key and returns a formatted log line.
  *
@@ -91,6 +97,7 @@ module.exports = {
  * contains the log message.
  * @param {string} levelLabel The name of the key in the `log` object that
  * contains the log level name.
+ * @param {PrettifyMessageExtras} extras Additional data available for message context
  * @returns {string}
  *
  * @example

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -22,7 +22,8 @@ module.exports = {
   prettifyMetadata: require('./prettify-metadata.js'),
   prettifyObject: require('./prettify-object.js'),
   prettifyTime: require('./prettify-time.js'),
-  splitPropertyKey: require('./split-property-key.js')
+  splitPropertyKey: require('./split-property-key.js'),
+  getLevelLabelData: require('./get-level-label-data')
 }
 
 // The remainder of this file consists of jsdoc blocks that are difficult to

--- a/lib/utils/parse-factory-options.js
+++ b/lib/utils/parse-factory-options.js
@@ -8,6 +8,7 @@ const {
 const colors = require('../colors')
 const handleCustomLevelsOpts = require('./handle-custom-levels-opts')
 const handleCustomLevelsNamesOpts = require('./handle-custom-levels-names-opts')
+const handleLevelLabelData = require('./get-level-label-data')
 
 /**
  * A `PrettyContext` is an object to be used by the various functions that
@@ -32,6 +33,7 @@ const handleCustomLevelsNamesOpts = require('./handle-custom-levels-names-opts')
  * should be considered as holding error objects.
  * @property {string[]} errorProps A list of error object keys that should be
  * included in the output.
+ * @property {function} getLevelLabelData Pass a numeric level to return [levelLabelString,levelNum]
  * @property {boolean} hideObject Indicates the prettifier should omit objects
  * in the output.
  * @property {string[]} ignoreKeys Set of log data keys to omit.
@@ -84,6 +86,7 @@ function parseFactoryOptions (options) {
     : (options.useOnlyCustomProps === 'true')
   const customLevels = handleCustomLevelsOpts(options.customLevels)
   const customLevelNames = handleCustomLevelsNamesOpts(options.customLevels)
+  const getLevelLabelData = handleLevelLabelData(useOnlyCustomProps, customLevels, customLevelNames)
 
   let customColors
   if (options.customColors) {
@@ -135,6 +138,7 @@ function parseFactoryOptions (options) {
     customProperties,
     errorLikeObjectKeys,
     errorProps,
+    getLevelLabelData,
     hideObject,
     ignoreKeys,
     includeKeys,

--- a/lib/utils/prettify-level.js
+++ b/lib/utils/prettify-level.js
@@ -35,7 +35,7 @@ function prettifyLevel ({ log, context }) {
   const labelColorized = colorizer(output, { customLevels, customLevelNames })
   if (prettifier) {
     const [label] = getLevelLabelData(output)
-    return prettifier(output, { label, labelColorized })
+    return prettifier(output, levelKey, log, { label, labelColorized, colors: colorizer.colors })
   }
   return labelColorized
 }

--- a/lib/utils/prettify-level.js
+++ b/lib/utils/prettify-level.js
@@ -26,10 +26,16 @@ function prettifyLevel ({ log, context }) {
     colorizer,
     customLevels,
     customLevelNames,
-    levelKey
+    levelKey,
+    getLevelLabelData
   } = context
   const prettifier = context.customPrettifiers?.level
   const output = getPropertyValue(log, levelKey)
   if (output === undefined) return undefined
-  return prettifier ? prettifier(output) : colorizer(output, { customLevels, customLevelNames })
+  const labelColorized = colorizer(output, { customLevels, customLevelNames })
+  if (prettifier) {
+    const [label] = getLevelLabelData(output)
+    return prettifier(output, { label, labelColorized })
+  }
+  return labelColorized
 }

--- a/lib/utils/prettify-level.test.js
+++ b/lib/utils/prettify-level.test.js
@@ -3,6 +3,7 @@
 const tap = require('tap')
 const prettifyLevel = require('./prettify-level')
 const getColorizer = require('../colors')
+const getLevelLabelData = require('./get-level-label-data')
 const {
   LEVEL_KEY
 } = require('../constants')
@@ -12,7 +13,8 @@ const context = {
   customLevelNames: undefined,
   customLevels: undefined,
   levelKey: LEVEL_KEY,
-  customPrettifiers: undefined
+  customPrettifiers: undefined,
+  getLevelLabelData: getLevelLabelData(false, {}, {})
 }
 
 tap.test('returns `undefined` for unknown level', async t => {

--- a/lib/utils/prettify-message.js
+++ b/lib/utils/prettify-message.js
@@ -54,7 +54,7 @@ function prettifyMessage ({ log, context }) {
     return colorizer.message(message)
   }
   if (messageFormat && typeof messageFormat === 'function') {
-    const msg = messageFormat(log, messageKey, levelLabel)
+    const msg = messageFormat(log, messageKey, levelLabel, { colors: colorizer.colors })
     return colorizer.message(msg)
   }
   if (messageKey in log === false) return undefined

--- a/lib/utils/prettify-message.test.js
+++ b/lib/utils/prettify-message.test.js
@@ -185,3 +185,37 @@ tap.test('`messageFormat` supports function definition', async t => {
   })
   t.equal(str, '--> localhost/test')
 })
+
+tap.test('`messageFormat` supports function definition with colorizer object', async t => {
+  const colorizer = getColorizer(true)
+  const str = prettifyMessage({
+    log: { level: 30, request: { url: 'localhost/test' }, msg: 'incoming request' },
+    context: {
+      ...context,
+      colorizer,
+      messageFormat: (log, messageKey, levelLabel, { colors }) => {
+        let msg = log[messageKey]
+        if (msg === 'incoming request') msg = `--> ${colors.red(log.request.url)}`
+        return msg
+      }
+    }
+  })
+  t.equal(str, '\u001B[36m--> \u001B[31mlocalhost/test\u001B[36m\u001B[39m')
+})
+
+tap.test('`messageFormat` supports function definition with colorizer object when no color is supported', async t => {
+  const colorizer = getColorizer(false)
+  const str = prettifyMessage({
+    log: { level: 30, request: { url: 'localhost/test' }, msg: 'incoming request' },
+    context: {
+      ...context,
+      colorizer,
+      messageFormat: (log, messageKey, levelLabel, { colors }) => {
+        let msg = log[messageKey]
+        if (msg === 'incoming request') msg = `--> ${colors.red(log.request.url)}`
+        return msg
+      }
+    }
+  })
+  t.equal(str, '--> localhost/test')
+})

--- a/lib/utils/prettify-message.test.js
+++ b/lib/utils/prettify-message.test.js
@@ -203,6 +203,23 @@ tap.test('`messageFormat` supports function definition with colorizer object', a
   t.equal(str, '\u001B[36m--> \u001B[31mlocalhost/test\u001B[36m\u001B[39m')
 })
 
+tap.test('`messageFormat` supports function definition with colorizer object when using custom colors', async t => {
+  const colorizer = getColorizer(true, [[30, 'brightGreen']], false)
+  const str = prettifyMessage({
+    log: { level: 30, request: { url: 'localhost/test' }, msg: 'incoming request' },
+    context: {
+      ...context,
+      colorizer,
+      messageFormat: (log, messageKey, levelLabel, { colors }) => {
+        let msg = log[messageKey]
+        if (msg === 'incoming request') msg = `--> ${colors.red(log.request.url)}`
+        return msg
+      }
+    }
+  })
+  t.equal(str, '\u001B[36m--> \u001B[31mlocalhost/test\u001B[36m\u001B[39m')
+})
+
 tap.test('`messageFormat` supports function definition with colorizer object when no color is supported', async t => {
   const colorizer = getColorizer(false)
   const str = prettifyMessage({

--- a/lib/utils/prettify-object.js
+++ b/lib/utils/prettify-object.js
@@ -43,7 +43,8 @@ function prettifyObject ({
     customPrettifiers,
     errorLikeObjectKeys: errorLikeKeys,
     objectColorizer,
-    singleLine
+    singleLine,
+    colorizer
   } = context
   const keysToIgnore = [].concat(skipKeys)
 
@@ -57,7 +58,7 @@ function prettifyObject ({
     if (keysToIgnore.includes(k) === false) {
       // Pre-apply custom prettifiers, because all 3 cases below will need this
       const pretty = typeof customPrettifiers[k] === 'function'
-        ? customPrettifiers[k](v, k, log)
+        ? customPrettifiers[k](v, k, log, { colors: colorizer.colors })
         : v
       if (errorLikeKeys.includes(k)) {
         errors[k] = pretty

--- a/lib/utils/prettify-object.test.js
+++ b/lib/utils/prettify-object.test.js
@@ -6,6 +6,7 @@ const prettifyObject = require('./prettify-object')
 const {
   ERROR_LIKE_KEYS
 } = require('../constants')
+const getColorizer = require('../colors')
 
 const context = {
   EOL: '\n',
@@ -13,7 +14,8 @@ const context = {
   customPrettifiers: {},
   errorLikeObjectKeys: ERROR_LIKE_KEYS,
   objectColorizer: colors(),
-  singleLine: false
+  singleLine: false,
+  colorizer: getColorizer()
 }
 
 tap.test('returns empty string if no properties present', async t => {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -259,7 +259,7 @@ test('basic prettifier tests', (t) => {
   t.test('can use a customPrettifier to get final level label (no color)', (t) => {
     t.plan(1)
     const customPrettifiers = {
-      level: (level, { label }) => {
+      level: (level, key, logThis, { label }) => {
         return `LEVEL: ${label}`
       }
     }
@@ -280,7 +280,7 @@ test('basic prettifier tests', (t) => {
   t.test('can use a customPrettifier to get final level label (colorized)', (t) => {
     t.plan(1)
     const customPrettifiers = {
-      level: (level, { label, labelColorized }) => {
+      level: (level, key, logThis, { label, labelColorized }) => {
         return `LEVEL: ${labelColorized}`
       }
     }

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -256,6 +256,48 @@ test('basic prettifier tests', (t) => {
     log.info({ msg: 'foo', bar: 'warn' })
   })
 
+  t.test('can use a customPrettifier to get final level label (no color)', (t) => {
+    t.plan(1)
+    const customPrettifiers = {
+      level: (level, { label }) => {
+        return `LEVEL: ${label}`
+      }
+    }
+    const pretty = prettyFactory({ customPrettifiers, colorize: false, useOnlyCustomProps: false })
+    const log = pino({}, new Writable({
+      write (chunk, enc, cb) {
+        const formatted = pretty(chunk.toString())
+        t.equal(
+          formatted,
+          `[${formattedEpoch}] LEVEL: INFO (${pid}): foo\n`
+        )
+        cb()
+      }
+    }))
+    log.info({ msg: 'foo' })
+  })
+
+  t.test('can use a customPrettifier to get final level label (colorized)', (t) => {
+    t.plan(1)
+    const customPrettifiers = {
+      level: (level, { label, labelColorized }) => {
+        return `LEVEL: ${labelColorized}`
+      }
+    }
+    const pretty = prettyFactory({ customPrettifiers, colorize: true, useOnlyCustomProps: false })
+    const log = pino({}, new Writable({
+      write (chunk, enc, cb) {
+        const formatted = pretty(chunk.toString())
+        t.equal(
+          formatted,
+          `[${formattedEpoch}] LEVEL: [32mINFO[39m (${pid}): [36mfoo[39m\n`
+        )
+        cb()
+      }
+    }))
+    log.info({ msg: 'foo' })
+  })
+
   t.test('can use a customPrettifier on name output', (t) => {
     t.plan(1)
     const customPrettifiers = {

--- a/test/types/pino-pretty.test-d.ts
+++ b/test/types/pino-pretty.test-d.ts
@@ -32,6 +32,9 @@ const options: PinoPretty.PrettyOptions = {
   customPrettifiers: {
     key: (value) => {
       return value.toString().toUpperCase();
+    },
+    level: (level, label, colorized) => {
+      return level.toString();
     }
   },
   customLevels: 'verbose:5',


### PR DESCRIPTION
This PR is combined changes from #493 and #494 (see these comments [1](https://github.com/pinojs/pino-pretty/pull/493#issuecomment-1964469268) [2](https://github.com/pinojs/pino-pretty/pull/493#issuecomment-1971957478)). Summary of changes:

## Extend/Normalize all "format" functions with `extras` object

All "format" functions -- `customPrettifiers`, `level`, and `messageFormat` -- now have an additional parameter, `extras` that is an object of `Record<string, any>`. This allows for additional data and future (optional) functionality to be provided to these functions without having to change function signature again.

This change is backward compatible but the examples in the documentation for these functions has been updated to include the existing, full, list of parameters that were available instead of just the first parameter. EX

Previous:

```js
{
  customPrettifiers: {
    caller: caller => `My Caller: ${caller}`
  }
}
```
```js
{
  messageFormat: (log, messageKey, levelLabel) => {
    return customized_message;
  }
}
```

New:
```js
{
  customPrettifiers: {
    caller: (caller, key, log, extras) => `My Caller: ${caller}`,
  }
}
```
```js
{
  messageFormat: (log, messageKey, levelLabel, extras) => {
    return `This is a custom message: ${log[messageKey]}`;
  }
}
```

## Provide Colorette `colors` to all "format" functions #494

Enables users to use available colors based on `colorize` context of the pino-pretty instance.

Currently if a user wants to color their messages they need to create their own instances of Colorette and implement logic, outside of pino-pretty, to make sure the `useColors` option passed matches what was given to pino-pretty as `colorize`. However pino-pretty already has this object available...this PR provides `colors` to the `extras` object for all format functions so that the user doesn't need to do that extra work.

```js
{
  customPrettifiers: {
    caller: (caller, key, log, { colors } ) => `${colors.greenBright(caller)}`,
  },
  messageFormat: (log, messageKey, levelLabel, { colors }) => {
    // do some log message customization
    //
    // `colors` is a Colorette object with colors enabled based on `colorize` option
    return `This is a ${color.red('colorized')}, custom message: ${log[messageKey]}`;
  }
}
```

## Add context to `level` customPrettifier #493

Currently the customPrettifier for `level` only returns the numeric level value (if `levelKey` is not used) which means that anyone who wants to modify value returned has to re-implement the levels pino-pretty already has access to as well as calculate the label to use, which pino-pretty also already does. 

This PR include both the "final" log label as well as the colorized output, if applicable, to `level` prettifier function to give users more control over level output. These values are included in the `extras` object:

```js
{
  customPrettifiers: {
  // level provides additional data in `extras`:
  // * label => derived level label string
  // * labelColorized => derived level label string with colorette colors applied based on customColors and whether colors are supported
  level: (logLevel, key, log, { label, labelColorized, colors }) => `LEVEL: ${logLevel} LABEL: ${levelLabel} COLORIZED LABEL: ${labelColorized}`,
  }
}
```

It has the additional benefit of enabling users to handle their own level alignment (#489 #140) since they have access to the final string values for level. As example implementation for aligning with spaces:

```js
{
  customPrettifiers: {
        level: (logLevel, key, log, { label, labelColorized }) => {
            // pad to fix alignment
            // assuming longest level is VERBOSE
            // and may be colorized
            const paddedLabel = label.padEnd(8)
            if(labelColorized !== label) {
                const padDiff = paddedLabel.length - label.length;
                return labelColorized.padEnd(labelColorized.length + padDiff);
            }
            return paddedLabel;
        }
    },
}
```