### PR TITLE
chore(license): make detectable by GitHub

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 the Pino team
-
-Pino team listed at https://github.com/pinojs/pino#the-team
+Copyright (c) 2019 the Pino team listed at https://github.com/pinojs/pino#the-team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Same issue as pinojs/pino#1859

Currently, GitHub cannot detect the license for this project. The note about the pino team in the LICENSE file prevents GitHub from being able to detect the license. The GitHub documentation notes the following:

> If your repository is using a license that is listed on the Choose a License website and it's not displaying clearly at the top of the repository page, it may contain multiple licenses or other complexity. To have your license detected, simplify your _LICENSE_ file and note the complexity somewhere else, such as your repository's _README_ file.

In order to keep the whole thing intact and allow the license to be detected, I combined the two lines.

GitHub [uses the ruby gem licensee](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository#detecting-a-license) to detect the license. I used that to test the changes.

### Before:

```
$ licensee detect pino-pretty
License:        NOASSERTION
Matched files:  LICENSE, Readme.md, package.json
LICENSE:
  Content hash:  3e2878c68c523a2ce826187ce962f00041d8a2d8
  License:       NOASSERTION
  Closest non-matching licenses:
    MIT similarity:    90.29%
    MIT-0 similarity:  69.71%
    NCSA similarity:   59.06%
Readme.md:
  Content hash:  da39a3ee5e6b4b0d3255bfef95601890afd80709
  Confidence:    90.00%
  Matcher:       Licensee::Matchers::Reference
  License:       MIT
  Closest non-matching licenses:
    0BSD similarity:   0.00%
    WTFPL similarity:  0.00%
    Vim similarity:    0.00%
package.json:
  Confidence:  90.00%
  Matcher:     Licensee::Matchers::NpmBower
  License:     MIT
```

### After:

```
$ licensee detect pino-pretty
License:        MIT
Matched files:  LICENSE, Readme.md, package.json
LICENSE:
  Content hash:  4c2c763d64bbc7ef2e58b0ec6d06d90cee9755c9
  Attribution:   Copyright (c) 2019 the Pino team listed at https://github.com/pinojs/pino#the-team
  Confidence:    100.00%
  Matcher:       Licensee::Matchers::Exact
  License:       MIT
Readme.md:
  Content hash:  da39a3ee5e6b4b0d3255bfef95601890afd80709
  Confidence:    90.00%
  Matcher:       Licensee::Matchers::Reference
  License:       MIT
  Closest non-matching licenses:
    0BSD similarity:   0.00%
    WTFPL similarity:  0.00%
    Vim similarity:    0.00%
package.json:
  Confidence:  90.00%
  Matcher:     Licensee::Matchers::NpmBower
  License:     MIT
```