### PR TITLE
feat: Added exports color support in TTY

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -230,6 +230,19 @@ module.exports = opts => require('pino-pretty')({
 })
 ```
 
+### Checking color support in TTY
+
+This boolean returns whether the currently used TTY supports colorizing the logs.
+
+```js
+import pretty from 'pino-pretty'
+
+if (pretty.isColorSupported) {
+  ...
+}
+
+```
+
 <a id="options"></a>
 ### Options
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -213,6 +213,7 @@ interface PrettyOptions_ {
 }
 
 declare function build(options: PrettyOptions_): PinoPretty.PrettyStream;
+type isColorSupported = PinoPretty.isColorSupported
 
 declare namespace PinoPretty {
   type Prettifier<T = object> = (inputData: string | object, key: string, log: object, extras: PrettifierExtras<T>) => string;
@@ -224,7 +225,8 @@ declare namespace PinoPretty {
   type ColorizerFactory = typeof colorizerFactory;
   type PrettyFactory = typeof prettyFactory;
   type Build = typeof build;
+  type isColorSupported = typeof Colorette.isColorSupported;
 }
 
 export default PinoPretty;
-export { build, PinoPretty, PrettyOptions_ as PrettyOptions, colorizerFactory, prettyFactory };
+export { build, PinoPretty, PrettyOptions_ as PrettyOptions, colorizerFactory, prettyFactory, isColorSupported };

--- a/index.js
+++ b/index.js
@@ -178,4 +178,5 @@ module.exports = build
 module.exports.build = build
 module.exports.prettyFactory = prettyFactory
 module.exports.colorizerFactory = colors
+module.exports.isColorSupported = isColorSupported
 module.exports.default = build

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1179,6 +1179,12 @@ test('basic prettifier tests', (t) => {
     log.info('foo')
   })
 
+  t.test('check support for colors', (t) => {
+    t.plan(1)
+    const isColorSupported = pinoPretty.isColorSupported
+    t.type(isColorSupported, 'boolean')
+  })
+
   t.end()
 })
 


### PR DESCRIPTION
- Exporting `isColorSupported` from `Colorette` to check for color support without installing the dependency again.
- Also required in this PR https://github.com/fastify/one-line-logger/pull/42