### PR TITLE
Fix: add missing useOnlyCustomProps options to type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -210,6 +210,12 @@ interface PrettyOptions_ {
    * @example ( Object ) customColors: { info: 'white', some_level: 'red' }
    */
   customColors?: string|object;
+  /**
+   * Only use custom levels and colors (if provided); else fallback to default levels and colors.
+   *
+   * @default true
+   */
+  useOnlyCustomProps?: boolean;
 }
 
 declare function build(options: PrettyOptions_): PinoPretty.PrettyStream;

--- a/test/types/pino-pretty.test-d.ts
+++ b/test/types/pino-pretty.test-d.ts
@@ -43,6 +43,7 @@ const options: PinoPretty.PrettyOptions = {
   destination: 2,
   append: true,
   mkdir: true,
+  useOnlyCustomProps: false,
 };
 
 expectType<PrettyStream>(pretty()); // #326


### PR DESCRIPTION
Hello,

I started using pino-pretty in a TypeScript project and noticed the `useOnlyCustomProps` option is not present in the type definitions module. The JSDoc lists it at [L71-72](https://github.com/pinojs/pino-pretty/blob/77e85fdcf3413b5064c5258ea3b858eac230340f/index.js#L71-L72), so I assume it was a copy-paste error at some time.

This pull request addresses this discrepancy by copying the [readme's description](https://github.com/pinojs/pino-pretty/blob/77e85fdcf3413b5064c5258ea3b858eac230340f/Readme.md?plain=1#L80)!