### PR TITLE
Readme.md: remove the command prompt symbol

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -40,7 +40,7 @@ prettified logs will look like:
 ## Install
 
 ```sh
-$ npm install -g pino-pretty
+npm install -g pino-pretty
 ```
 
 <a id="usage"></a>


### PR DESCRIPTION
Remove "$" because otherwise, it will also be copied to the clipboard and the pasted command will produce an error.