### PR TITLE
fix: loosen up customPrettifiers typing constraints

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -185,7 +185,7 @@ declare namespace PinoPretty {
      */
     customPrettifiers?: Record<string, Prettifier> &
       {
-        level?: Prettifier<LevelPrettifierExtras>
+        level?: Prettifier
       };
     /**
      * Change the level names and values to an user custom preset.
@@ -218,9 +218,8 @@ declare namespace PinoPretty {
 
   function build(options: PrettyOptions): PrettyStream;
 
-  type Prettifier<T = object> = (inputData: string | object, key: string, log: object, extras: PrettifierExtras<T>) => string;
-  type PrettifierExtras<T = object> = {colors: Colorette.Colorette} & T;
-  type LevelPrettifierExtras = {label: string, labelColorized: string}
+  type Prettifier = (inputData: string | object, key: string, log: object, extras: PrettifierExtras) => string;
+  type PrettifierExtras = {colors: Colorette.Colorette, label: string, labelColorized: string};
   type MessageFormatFunc = (log: LogDescriptor, messageKey: string, levelLabel: string, extras: PrettifierExtras) => string;
   type PrettyStream = Transform & OnUnknown;
   type ColorizerFactory = typeof colorizerFactory;

--- a/test/types/pino-pretty.test-d.ts
+++ b/test/types/pino-pretty.test-d.ts
@@ -33,8 +33,11 @@ const options: PinoPretty.PrettyOptions = {
     key: (value) => {
       return value.toString().toUpperCase();
     },
-    level: (level, label, colorized) => {
+    level: (level, levelKey, log, { label, labelColorized, colors }) => {
       return level.toString();
+    },
+    foo: (value, key, log, { colors }) => {
+      return value.toString();
     }
   },
   customLevels: 'verbose:5',


### PR DESCRIPTION
The fourth parameter of the 'level' custom prettifier -- extras -- used to have a separate type as pino-pretty offered two additional attributes to this particular prettifier.

However since it used a Record<string, T> type, TypeScript required all values to be compatible with each other. So when users tried to use the extras parameter for 'level', it caused

    error TS2322: Type '{ level: (_level: string | object, _levelKey: string, _log: object, { labelColorized }: PrettifierExtras<LevelPrettifierExtras>) => string; }' is not assignable to type 'Record<string, Prettifier<object>> & { level?: Prettifier<LevelPrettifierExtras> | undefined; }'.
    Type '{ level: (_level: string | object, _levelKey: string, _log: object, { labelColorized }: PrettifierExtras<LevelPrettifierExtras>) => string; }' is not assignable to type 'Record<string, Prettifier<object>>'.
        Property 'level' is incompatible with index signature.
        Type '(_level: string | object, _levelKey: string, _log: object, { labelColorized }: PrettifierExtras<LevelPrettifierExtras>) => string' is not assignable to type 'Prettifier<object>'.
            Types of parameters '__3' and 'extras' are incompatible.
            Type 'PrettifierExtras<object>' is not assignable to type 'PrettifierExtras<LevelPrettifierExtras>'.
                Type '{ colors: Colorette; }' is missing the following properties from type 'LevelPrettifierExtras': label, labelColorized

    115     customPrettifiers: {
            ~~~~~~~~~~~~~~~~~

This patch remedies this issue by merging LevelPrettifierExtras into PrettifierExtras. These types are not exported directly, therefore users, including those who leverage TypeScript utility types to extract these types, should be able to upgrade directly.

Fixes #550