### PR TITLE
Add magenta as the color for printed object properties. Fixes suport for `--no-colorizeObjects`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -57,7 +57,7 @@ node app.js | pino-pretty
 ### CLI Arguments
 
 - `--colorize` (`-c`): Adds terminal color escape sequences to the output.
-- `--colorizeObjects` (`-C`): Allows suppressing colorization of objects when set to `false`. In combination with `--singleLine`, this ensures that the end of each line is parsable JSON.
+- `--no-colorizeObjects`: Suppress colorization of objects.
 - `--crlf` (`-f`): Appends carriage return and line feed, instead of just a line
   feed, to the formatted log line.
 - `--errorProps` (`-e`): When formatting an error object, display this list

--- a/bin.js
+++ b/bin.js
@@ -41,7 +41,6 @@ if (cmd.h || cmd.help) {
   let opts = minimist(process.argv, {
     alias: {
       colorize: 'c',
-      colorizeObjects: 'C',
       crlf: 'f',
       errorProps: 'e',
       levelFirst: 'l',

--- a/lib/colors.js
+++ b/lib/colors.js
@@ -10,13 +10,14 @@ const plain = {
   20: nocolor,
   10: nocolor,
   message: nocolor,
-  greyMessage: nocolor
+  greyMessage: nocolor,
+  property: nocolor
 }
 
 const { createColors } = require('colorette')
 const getLevelLabelData = require('./utils/get-level-label-data')
 const availableColors = createColors({ useColor: true })
-const { white, bgRed, red, yellow, green, blue, gray, cyan } = availableColors
+const { white, bgRed, red, yellow, green, blue, gray, cyan, magenta } = availableColors
 
 const colored = {
   default: white,
@@ -27,7 +28,8 @@ const colored = {
   20: blue,
   10: gray,
   message: cyan,
-  greyMessage: gray
+  greyMessage: gray,
+  property: magenta
 }
 
 function resolveCustomColoredColorizer (customColors) {
@@ -56,6 +58,7 @@ function plainColorizer (useOnlyCustomProps) {
   }
   customColoredColorizer.message = plain.message
   customColoredColorizer.greyMessage = plain.greyMessage
+  customColoredColorizer.property = plain.property
   customColoredColorizer.colors = createColors({ useColor: false })
   return customColoredColorizer
 }
@@ -66,6 +69,7 @@ function coloredColorizer (useOnlyCustomProps) {
     return newColoredColorizer(level, colored, opts)
   }
   customColoredColorizer.message = colored.message
+  customColoredColorizer.property = colored.property
   customColoredColorizer.greyMessage = colored.greyMessage
   customColoredColorizer.colors = availableColors
   return customColoredColorizer

--- a/lib/utils/prettify-error-log.test.js
+++ b/lib/utils/prettify-error-log.test.js
@@ -2,6 +2,7 @@
 
 const tap = require('tap')
 const prettifyErrorLog = require('./prettify-error-log')
+const colors = require('../colors')
 const {
   ERROR_LIKE_KEYS,
   MESSAGE_KEY
@@ -13,7 +14,8 @@ const context = {
   customPrettifiers: {},
   errorLikeObjectKeys: ERROR_LIKE_KEYS,
   errorProps: [],
-  messageKey: MESSAGE_KEY
+  messageKey: MESSAGE_KEY,
+  objectColorizer: colors()
 }
 
 tap.test('returns string with default settings', async t => {

--- a/lib/utils/prettify-object.js
+++ b/lib/utils/prettify-object.js
@@ -92,7 +92,7 @@ function prettifyObject ({
       lines = lines.replace(/\\\\/gi, '\\')
 
       const joinedLines = joinLinesWithIndentation({ input: lines, ident, eol })
-      result += `${ident}${keyName}:${joinedLines.startsWith(eol) ? '' : ' '}${joinedLines}${eol}`
+      result += `${ident}${objectColorizer.property(keyName)}:${joinedLines.startsWith(eol) ? '' : ' '}${joinedLines}${eol}`
     })
   }
 

--- a/lib/utils/prettify-object.test.js
+++ b/lib/utils/prettify-object.test.js
@@ -6,7 +6,6 @@ const prettifyObject = require('./prettify-object')
 const {
   ERROR_LIKE_KEYS
 } = require('../constants')
-const getColorizer = require('../colors')
 
 const context = {
   EOL: '\n',
@@ -15,7 +14,7 @@ const context = {
   errorLikeObjectKeys: ERROR_LIKE_KEYS,
   objectColorizer: colors(),
   singleLine: false,
-  colorizer: getColorizer()
+  colorizer: colors()
 }
 
 tap.test('returns empty string if no properties present', async t => {
@@ -151,4 +150,17 @@ tap.test('errors skips prettifying if no lines are present', async t => {
     }
   })
   t.equal(str, '')
+})
+
+tap.test('works with single level properties', async t => {
+  const colorizer = colors(true)
+  const str = prettifyObject({
+    log: { foo: 'bar' },
+    context: {
+      ...context,
+      objectColorizer: colorizer,
+      colorizer
+    }
+  })
+  t.equal(str, `    ${colorizer.colors.magenta('foo')}: "bar"\n`)
 })


### PR DESCRIPTION
<img width="667" alt="Screenshot 2025-01-14 at 14 28 08" src="https://github.com/user-attachments/assets/27d74064-834c-4233-853f-27eadc31d04c" />


Fixes https://github.com/pinojs/pino-pretty/issues/537 as well.