### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 const help = require('help-me')({
   dir: path.join(__dirname, 'help'),
   ext: '.txt'

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@
 
 /// <reference types="node" />
 
-import { Transform } from 'stream';
+import { Transform } from 'node:stream';
 import { OnUnknown } from 'pino-abstract-transport';
 // @ts-ignore fall back to any if pino is not available, i.e. when running pino tests
 import { DestinationStream, Level } from 'pino';

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const { isColorSupported } = require('colorette')
 const pump = require('pump')
-const { Transform } = require('stream')
+const { Transform } = require('node:stream')
 const abstractTransport = require('pino-abstract-transport')
 const colors = require('./lib/colors')
 const {

--- a/lib/utils/build-safe-sonic-boom.js
+++ b/lib/utils/build-safe-sonic-boom.js
@@ -2,7 +2,7 @@
 
 module.exports = buildSafeSonicBoom
 
-const { isMainThread } = require('worker_threads')
+const { isMainThread } = require('node:worker_threads')
 const SonicBoom = require('sonic-boom')
 const noop = require('./noop')
 

--- a/lib/utils/build-safe-sonic-boom.test.js
+++ b/lib/utils/build-safe-sonic-boom.test.js
@@ -2,8 +2,8 @@
 
 const tap = require('tap')
 const rimraf = require('rimraf')
-const fs = require('fs')
-const { join } = require('path')
+const fs = require('node:fs')
+const { join } = require('node:path')
 
 const buildSafeSonicBoom = require('./build-safe-sonic-boom')
 

--- a/lib/utils/index.test.js
+++ b/lib/utils/index.test.js
@@ -2,8 +2,8 @@
 
 const tap = require('tap')
 const index = require('./index.js')
-const { readdirSync } = require('fs')
-const { basename } = require('path')
+const { readdirSync } = require('node:fs')
+const { basename } = require('node:path')
 
 tap.test(
   'index exports exactly all non-test files excluding itself',

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -2,15 +2,14 @@
 
 process.env.TZ = 'UTC'
 
-const { Writable } = require('stream')
-const os = require('os')
-const test = require('tap').test
+const { Writable } = require('node:stream')
+const os = require('node:os')
+const { test } = require('tap')
 const pino = require('pino')
 const dateformat = require('dateformat')
-const path = require('path')
 const rimraf = require('rimraf')
-const { join } = require('path')
-const fs = require('fs')
+const { join } = require('node:path')
+const fs = require('node:fs')
 const semver = require('semver')
 const pinoPretty = require('..')
 const SonicBoom = require('sonic-boom')
@@ -1148,7 +1147,7 @@ test('basic prettifier tests', (t) => {
 
   t.test('stream usage', async (t) => {
     t.plan(1)
-    const tmpDir = path.join(__dirname, '.tmp_' + Date.now())
+    const tmpDir = join(__dirname, '.tmp_' + Date.now())
     t.teardown(() => rimraf.sync(tmpDir))
 
     const destination = join(tmpDir, 'output')
@@ -1176,7 +1175,7 @@ test('basic prettifier tests', (t) => {
 
   t.test('sync option', async (t) => {
     t.plan(1)
-    const tmpDir = path.join(__dirname, '.tmp_' + Date.now())
+    const tmpDir = join(__dirname, '.tmp_' + Date.now())
     t.teardown(() => rimraf.sync(tmpDir))
 
     const destination = join(tmpDir, 'output')

--- a/test/cli-rc.test.js
+++ b/test/cli-rc.test.js
@@ -2,10 +2,10 @@
 
 process.env.TZ = 'UTC'
 
-const path = require('path')
-const spawn = require('child_process').spawn
-const test = require('tap').test
-const fs = require('fs')
+const path = require('node:path')
+const { spawn } = require('node:child_process')
+const { test } = require('tap')
+const fs = require('node:fs')
 const rimraf = require('rimraf')
 
 const bin = require.resolve('../bin')

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -2,9 +2,9 @@
 
 process.env.TZ = 'UTC'
 
-const path = require('path')
-const spawn = require('child_process').spawn
-const test = require('tap').test
+const path = require('node:path')
+const { spawn } = require('node:child_process')
+const { test } = require('tap')
 
 const bin = require.resolve(path.join(__dirname, '..', 'bin.js'))
 const epoch = 1522431328992

--- a/test/crlf.test.js
+++ b/test/crlf.test.js
@@ -2,7 +2,7 @@
 
 process.env.TZ = 'UTC'
 
-const test = require('tap').test
+const { test } = require('tap')
 const _prettyFactory = require('../').prettyFactory
 
 function prettyFactory (opts) {

--- a/test/error-objects.test.js
+++ b/test/error-objects.test.js
@@ -2,8 +2,8 @@
 
 process.env.TZ = 'UTC'
 
-const Writable = require('stream').Writable
-const test = require('tap').test
+const { Writable } = require('node:stream')
+const { test } = require('tap')
 const pino = require('pino')
 const semver = require('semver')
 const serializers = pino.stdSerializers

--- a/test/example/example.js
+++ b/test/example/example.js
@@ -2,7 +2,7 @@
 
 const _prettyFactory = require('../../')
 const pino = require('pino')
-const { Writable } = require('stream')
+const { Writable } = require('node:stream')
 
 function prettyFactory () {
   return _prettyFactory({


### PR DESCRIPTION
Allows redundant `require.cache` calls to be bypassed for builtin modules, saving a few yoctoseconds.

See https://nodejs.org/api/modules.html#core-modules and [discussion in nodejs/node repo regarding why `require.cache` calls are redundant for builtins](https://github.com/nodejs/node/pull/37246/files#r588397158).

Also cleaned up some of the imports by destructuring them whilst I was in the area.