### PR TITLE
perf: add missing `'use strict'` directives

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+'use strict'
+
 const fs = require('node:fs')
 const path = require('node:path')
 const help = require('help-me')({

--- a/test/example/example.js
+++ b/test/example/example.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // Run this to see how colouring works
 
 const _prettyFactory = require('../../')


### PR DESCRIPTION
This PR adds missing `'use strict'` directives to the cjs files in this repo. Strict mode can improve performance by eliminating some JavaScript features that hinder optimizations. It also helps avoid subtle bugs by enforcing more consistent scoping and variable declarations.

The [MDN article on strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode) alludes to it, but the V8 JS engine used by Node will use more optimised execution paths when strict mode is enabled. See [related Stack Overflow discussion](https://stackoverflow.com/questions/38411552/why-use-strict-improves-performance-10x-in-this-example) for an example.