### PR TITLE
test: move build-safe-sonic-boom.test.js to node test

### DIFF
--- a/lib/utils/build-safe-sonic-boom.test.js
+++ b/lib/utils/build-safe-sonic-boom.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const tap = require('tap')
+const { test } = require('node:test')
 const { rimraf } = require('rimraf')
 const fs = require('node:fs')
 const { join } = require('node:path')
@@ -13,53 +13,53 @@ const file = () => {
   return { dest, fd }
 }
 
-tap.test('should not write when error emitted and code is "EPIPE"', async t => {
+test('should not write when error emitted and code is "EPIPE"', async t => {
   t.plan(1)
 
   const { fd, dest } = file()
   const stream = buildSafeSonicBoom({ sync: true, fd, mkdir: true })
-  t.teardown(() => rimraf(dest))
+  t.after(() => rimraf(dest))
 
   stream.emit('error', { code: 'EPIPE' })
   stream.write('will not work')
 
   const dataFile = fs.readFileSync(dest)
-  t.equal(dataFile.length, 0)
+  t.assert.strictEqual(dataFile.length, 0)
 })
 
-tap.test('should stream.write works when error code is not "EPIPE"', async t => {
+test('should stream.write works when error code is not "EPIPE"', async t => {
   t.plan(3)
   const { fd, dest } = file()
   const stream = buildSafeSonicBoom({ sync: true, fd, mkdir: true })
 
-  t.teardown(() => rimraf(dest))
+  t.after(() => rimraf(dest))
 
-  stream.on('error', () => t.pass('error emitted'))
+  stream.on('error', () => t.assert.ok('error emitted'))
 
   stream.emit('error', 'fake error description')
 
-  t.ok(stream.write('will work'))
+  t.assert.ok(stream.write('will work'))
 
   const dataFile = fs.readFileSync(dest)
-  t.equal(dataFile.toString(), 'will work')
+  t.assert.strictEqual(dataFile.toString(), 'will work')
 })
 
-tap.test('cover setupOnExit', async t => {
+test('cover setupOnExit', async t => {
   t.plan(3)
   const { fd, dest } = file()
   const stream = buildSafeSonicBoom({ sync: false, fd, mkdir: true })
 
-  t.teardown(() => rimraf(dest))
+  t.after(() => rimraf(dest))
 
-  stream.on('error', () => t.pass('error emitted'))
+  stream.on('error', () => t.assert.ok('error emitted'))
   stream.emit('error', 'fake error description')
 
-  t.ok(stream.write('will work'))
+  t.assert.ok(stream.write('will work'))
 
   await watchFileCreated(dest)
 
   const dataFile = fs.readFileSync(dest)
-  t.equal(dataFile.toString(), 'will work')
+  t.assert.strictEqual(dataFile.toString(), 'will work')
 })
 
 function watchFileCreated (filename) {

--- a/lib/utils/build-safe-sonic-boom.test.js
+++ b/lib/utils/build-safe-sonic-boom.test.js
@@ -13,7 +13,7 @@ const file = () => {
   return { dest, fd }
 }
 
-test('should not write when error emitted and code is "EPIPE"', async t => {
+test('should not write when error emitted and code is "EPIPE"', t => {
   t.plan(1)
 
   const { fd, dest } = file()
@@ -27,7 +27,7 @@ test('should not write when error emitted and code is "EPIPE"', async t => {
   t.assert.strictEqual(dataFile.length, 0)
 })
 
-test('should stream.write works when error code is not "EPIPE"', async t => {
+test('should stream.write works when error code is not "EPIPE"', t => {
   t.plan(3)
   const { fd, dest } = file()
   const stream = buildSafeSonicBoom({ sync: true, fd, mkdir: true })


### PR DESCRIPTION
This PR moves `build-safe-sonic-boom.test.js` to node test