### PR TITLE
test: move filter-log.test.js to node test

### DIFF
--- a/lib/utils/filter-log.test.js
+++ b/lib/utils/filter-log.test.js
@@ -23,7 +23,7 @@ const logData2 = Object.assign({
 }, logData)
 
 describe('#filterLog with an ignoreKeys option', () => {
-  test('filterLog removes single entry', async t => {
+  test('filterLog removes single entry', t => {
     const result = filterLog({
       log: logData,
       context: {
@@ -34,7 +34,7 @@ describe('#filterLog with an ignoreKeys option', () => {
     t.assert.deepStrictEqual(result, { level: 30, time: 1522431328992, data1: { data2: { }, error: new Error('test') } })
   })
 
-  test('filterLog removes multiple entries', async t => {
+  test('filterLog removes multiple entries', t => {
     const result = filterLog({
       log: logData,
       context: {
@@ -45,7 +45,7 @@ describe('#filterLog with an ignoreKeys option', () => {
     t.assert.deepStrictEqual(result, { level: 30 })
   })
 
-  test('filterLog keeps error instance', async t => {
+  test('filterLog keeps error instance', t => {
     const result = filterLog({
       log: logData,
       context: {
@@ -56,7 +56,7 @@ describe('#filterLog with an ignoreKeys option', () => {
     t.assert.strictEqual(logData.data1.error, result.data1.error)
   })
 
-  test('filterLog removes entry with escape sequence', async t => {
+  test('filterLog removes entry with escape sequence', t => {
     const result = filterLog({
       log: logData2,
       context: {
@@ -67,7 +67,7 @@ describe('#filterLog with an ignoreKeys option', () => {
     t.assert.deepStrictEqual(result, { level: 30, time: 1522431328992 })
   })
 
-  test('filterLog removes entry with escape sequence nested', async t => {
+  test('filterLog removes entry with escape sequence nested', t => {
     const result = filterLog({
       log: logData2,
       context: {
@@ -85,7 +85,7 @@ for (const ignoreKeys of [
   ['level', 'data1.data2.data-3']
 ]) {
   describe(`#filterLog with an includeKeys option when the ignoreKeys being ${ignoreKeys}`, () => {
-    test('filterLog include nothing', async t => {
+    test('filterLog include nothing', t => {
       const result = filterLog({
         log: logData,
         context: {
@@ -97,7 +97,7 @@ for (const ignoreKeys of [
       t.assert.deepStrictEqual(result, {})
     })
 
-    test('filterLog include single entry', async t => {
+    test('filterLog include single entry', t => {
       const result = filterLog({
         log: logData,
         context: {
@@ -109,7 +109,7 @@ for (const ignoreKeys of [
       t.assert.deepStrictEqual(result, { time: 1522431328992 })
     })
 
-    test('filterLog include multiple entries', async t => {
+    test('filterLog include multiple entries', t => {
       const result = filterLog({
         log: logData,
         context: {
@@ -137,7 +137,7 @@ describe('#filterLog with circular references', () => {
   }
   logData.circular = logData
 
-  test('filterLog removes single entry', async t => {
+  test('filterLog removes single entry', t => {
     const result = filterLog({
       log: logData,
       context: {
@@ -153,7 +153,7 @@ describe('#filterLog with circular references', () => {
     t.assert.deepStrictEqual(result, { level: 30, time: 1522431328992 })
   })
 
-  test('filterLog includes single entry', async t => {
+  test('filterLog includes single entry', t => {
     const result = filterLog({
       log: logData,
       context: {
@@ -165,7 +165,7 @@ describe('#filterLog with circular references', () => {
     t.assert.deepStrictEqual(result, { data1: 'test' })
   })
 
-  test('filterLog includes circular keys', async t => {
+  test('filterLog includes circular keys', t => {
     const result = filterLog({
       log: logData,
       context: {

--- a/lib/utils/filter-log.test.js
+++ b/lib/utils/filter-log.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const tap = require('tap')
+const { describe, test } = require('node:test')
 const filterLog = require('./filter-log')
 
 const context = {
@@ -22,8 +22,8 @@ const logData2 = Object.assign({
   }
 }, logData)
 
-tap.test('#filterLog with an ignoreKeys option', t => {
-  t.test('filterLog removes single entry', async t => {
+describe('#filterLog with an ignoreKeys option', () => {
+  test('filterLog removes single entry', async t => {
     const result = filterLog({
       log: logData,
       context: {
@@ -31,10 +31,10 @@ tap.test('#filterLog with an ignoreKeys option', t => {
         ignoreKeys: ['data1.data2.data-3']
       }
     })
-    t.same(result, { level: 30, time: 1522431328992, data1: { data2: { }, error: new Error('test') } })
+    t.assert.deepStrictEqual(result, { level: 30, time: 1522431328992, data1: { data2: { }, error: new Error('test') } })
   })
 
-  t.test('filterLog removes multiple entries', async t => {
+  test('filterLog removes multiple entries', async t => {
     const result = filterLog({
       log: logData,
       context: {
@@ -42,10 +42,10 @@ tap.test('#filterLog with an ignoreKeys option', t => {
         ignoreKeys: ['time', 'data1']
       }
     })
-    t.same(result, { level: 30 })
+    t.assert.deepStrictEqual(result, { level: 30 })
   })
 
-  t.test('filterLog keeps error instance', async t => {
+  test('filterLog keeps error instance', async t => {
     const result = filterLog({
       log: logData,
       context: {
@@ -53,10 +53,10 @@ tap.test('#filterLog with an ignoreKeys option', t => {
         ignoreKeys: []
       }
     })
-    t.equal(logData.data1.error, result.data1.error)
+    t.assert.strictEqual(logData.data1.error, result.data1.error)
   })
 
-  t.test('filterLog removes entry with escape sequence', async t => {
+  test('filterLog removes entry with escape sequence', async t => {
     const result = filterLog({
       log: logData2,
       context: {
@@ -64,10 +64,10 @@ tap.test('#filterLog with an ignoreKeys option', t => {
         ignoreKeys: ['data1', 'logging\\.domain\\.corp/operation']
       }
     })
-    t.same(result, { level: 30, time: 1522431328992 })
+    t.assert.deepStrictEqual(result, { level: 30, time: 1522431328992 })
   })
 
-  t.test('filterLog removes entry with escape sequence nested', async t => {
+  test('filterLog removes entry with escape sequence nested', async t => {
     const result = filterLog({
       log: logData2,
       context: {
@@ -75,20 +75,17 @@ tap.test('#filterLog with an ignoreKeys option', t => {
         ignoreKeys: ['data1', 'logging\\.domain\\.corp/operation.producer']
       }
     })
-    t.same(result, { level: 30, time: 1522431328992, 'logging.domain.corp/operation': { id: 'foo' } })
+    t.assert.deepStrictEqual(result, { level: 30, time: 1522431328992, 'logging.domain.corp/operation': { id: 'foo' } })
   })
-
-  t.end()
 })
 
-const ignoreKeysArray = [
+for (const ignoreKeys of [
   undefined,
   ['level'],
   ['level', 'data1.data2.data-3']
-]
-ignoreKeysArray.forEach(ignoreKeys => {
-  tap.test(`#filterLog with an includeKeys option when the ignoreKeys being ${ignoreKeys}`, t => {
-    t.test('filterLog include nothing', async t => {
+]) {
+  describe(`#filterLog with an includeKeys option when the ignoreKeys being ${ignoreKeys}`, () => {
+    test('filterLog include nothing', async t => {
       const result = filterLog({
         log: logData,
         context: {
@@ -97,10 +94,10 @@ ignoreKeysArray.forEach(ignoreKeys => {
           includeKeys: []
         }
       })
-      t.same(result, {})
+      t.assert.deepStrictEqual(result, {})
     })
 
-    t.test('filterLog include single entry', async t => {
+    test('filterLog include single entry', async t => {
       const result = filterLog({
         log: logData,
         context: {
@@ -109,10 +106,10 @@ ignoreKeysArray.forEach(ignoreKeys => {
           includeKeys: ['time']
         }
       })
-      t.same(result, { time: 1522431328992 })
+      t.assert.deepStrictEqual(result, { time: 1522431328992 })
     })
 
-    t.test('filterLog include multiple entries', async t => {
+    test('filterLog include multiple entries', async t => {
       const result = filterLog({
         log: logData,
         context: {
@@ -121,7 +118,7 @@ ignoreKeysArray.forEach(ignoreKeys => {
           includeKeys: ['time', 'data1']
         }
       })
-      t.same(result, {
+      t.assert.deepStrictEqual(result, {
         time: 1522431328992,
         data1: {
           data2: { 'data-3': 'bar' },
@@ -129,12 +126,10 @@ ignoreKeysArray.forEach(ignoreKeys => {
         }
       })
     })
-
-    t.end()
   })
-})
+}
 
-tap.test('#filterLog with circular references', t => {
+describe('#filterLog with circular references', () => {
   const logData = {
     level: 30,
     time: 1522431328992,
@@ -142,7 +137,7 @@ tap.test('#filterLog with circular references', t => {
   }
   logData.circular = logData
 
-  t.test('filterLog removes single entry', async t => {
+  test('filterLog removes single entry', async t => {
     const result = filterLog({
       log: logData,
       context: {
@@ -151,14 +146,14 @@ tap.test('#filterLog with circular references', t => {
       }
     })
 
-    t.same(result.circular.level, result.level)
-    t.same(result.circular.time, result.time)
+    t.assert.deepStrictEqual(result.circular.level, result.level)
+    t.assert.deepStrictEqual(result.circular.time, result.time)
 
     delete result.circular
-    t.same(result, { level: 30, time: 1522431328992 })
+    t.assert.deepStrictEqual(result, { level: 30, time: 1522431328992 })
   })
 
-  t.test('filterLog includes single entry', async t => {
+  test('filterLog includes single entry', async t => {
     const result = filterLog({
       log: logData,
       context: {
@@ -167,10 +162,10 @@ tap.test('#filterLog with circular references', t => {
       }
     })
 
-    t.same(result, { data1: 'test' })
+    t.assert.deepStrictEqual(result, { data1: 'test' })
   })
 
-  t.test('filterLog includes circular keys', async t => {
+  test('filterLog includes circular keys', async t => {
     const result = filterLog({
       log: logData,
       context: {
@@ -179,12 +174,10 @@ tap.test('#filterLog with circular references', t => {
       }
     })
 
-    t.same(result.circular.level, logData.level)
-    t.same(result.circular.time, logData.time)
+    t.assert.deepStrictEqual(result.circular.level, logData.level)
+    t.assert.deepStrictEqual(result.circular.time, logData.time)
 
     delete result.circular
-    t.same(result, { level: 30 })
+    t.assert.deepStrictEqual(result, { level: 30 })
   })
-
-  t.end()
 })


### PR DESCRIPTION
This PR moves `filter-log.test.js` to node test