### PR TITLE
test: move format-time.test.js to node test

### DIFF
--- a/lib/utils/format-time.test.js
+++ b/lib/utils/format-time.test.js
@@ -9,63 +9,63 @@ const dateStr = '2019-04-06T13:30:00.000-04:00'
 const epoch = new Date(dateStr)
 const epochMS = epoch.getTime()
 
-test('passes through epoch if `translateTime` is `false`', async t => {
+test('passes through epoch if `translateTime` is `false`', t => {
   const formattedTime = formatTime(epochMS)
   t.assert.strictEqual(formattedTime, epochMS)
 })
 
-test('passes through epoch if date is invalid', async t => {
+test('passes through epoch if date is invalid', t => {
   const input = 'this is not a date'
   const formattedTime = formatTime(input, true)
   t.assert.strictEqual(formattedTime, input)
 })
 
-test('translates epoch milliseconds if `translateTime` is `true`', async t => {
+test('translates epoch milliseconds if `translateTime` is `true`', t => {
   const formattedTime = formatTime(epochMS, true)
   t.assert.strictEqual(formattedTime, '17:30:00.000')
 })
 
-test('translates epoch milliseconds to UTC string given format', async t => {
+test('translates epoch milliseconds to UTC string given format', t => {
   const formattedTime = formatTime(epochMS, 'd mmm yyyy H:MM')
   t.assert.strictEqual(formattedTime, '6 Apr 2019 17:30')
 })
 
-test('translates epoch milliseconds to SYS:STANDARD', async t => {
+test('translates epoch milliseconds to SYS:STANDARD', t => {
   const formattedTime = formatTime(epochMS, 'SYS:STANDARD')
   t.assert.match(formattedTime, /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} [-+]?\d{4}/)
 })
 
-test('translates epoch milliseconds to SYS:<FORMAT>', async t => {
+test('translates epoch milliseconds to SYS:<FORMAT>', t => {
   const formattedTime = formatTime(epochMS, 'SYS:d mmm yyyy H:MM')
   t.assert.match(formattedTime, /\d{1} \w{3} \d{4} \d{1,2}:\d{2}/)
 })
 
-test('passes through date string if `translateTime` is `false`', async t => {
+test('passes through date string if `translateTime` is `false`', t => {
   const formattedTime = formatTime(dateStr)
   t.assert.strictEqual(formattedTime, dateStr)
 })
 
-test('translates date string if `translateTime` is `true`', async t => {
+test('translates date string if `translateTime` is `true`', t => {
   const formattedTime = formatTime(dateStr, true)
   t.assert.strictEqual(formattedTime, '17:30:00.000')
 })
 
-test('translates date string to UTC string given format', async t => {
+test('translates date string to UTC string given format', t => {
   const formattedTime = formatTime(dateStr, 'd mmm yyyy H:MM')
   t.assert.strictEqual(formattedTime, '6 Apr 2019 17:30')
 })
 
-test('translates date string to SYS:STANDARD', async t => {
+test('translates date string to SYS:STANDARD', t => {
   const formattedTime = formatTime(dateStr, 'SYS:STANDARD')
   t.assert.match(formattedTime, /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} [-+]?\d{4}/)
 })
 
-test('translates date string to UTC:<FORMAT>', async t => {
+test('translates date string to UTC:<FORMAT>', t => {
   const formattedTime = formatTime(dateStr, 'UTC:d mmm yyyy H:MM')
   t.assert.strictEqual(formattedTime, '6 Apr 2019 17:30')
 })
 
-test('translates date string to SYS:<FORMAT>', async t => {
+test('translates date string to SYS:<FORMAT>', t => {
   const formattedTime = formatTime(dateStr, 'SYS:d mmm yyyy H:MM')
   t.assert.match(formattedTime, /\d{1} \w{3} \d{4} \d{1,2}:\d{2}/)
 })

--- a/lib/utils/format-time.test.js
+++ b/lib/utils/format-time.test.js
@@ -2,70 +2,70 @@
 
 process.env.TZ = 'UTC'
 
-const tap = require('tap')
+const { test } = require('node:test')
 const formatTime = require('./format-time')
 
 const dateStr = '2019-04-06T13:30:00.000-04:00'
 const epoch = new Date(dateStr)
 const epochMS = epoch.getTime()
 
-tap.test('passes through epoch if `translateTime` is `false`', async t => {
+test('passes through epoch if `translateTime` is `false`', async t => {
   const formattedTime = formatTime(epochMS)
-  t.equal(formattedTime, epochMS)
+  t.assert.strictEqual(formattedTime, epochMS)
 })
 
-tap.test('passes through epoch if date is invalid', async t => {
+test('passes through epoch if date is invalid', async t => {
   const input = 'this is not a date'
   const formattedTime = formatTime(input, true)
-  t.equal(formattedTime, input)
+  t.assert.strictEqual(formattedTime, input)
 })
 
-tap.test('translates epoch milliseconds if `translateTime` is `true`', async t => {
+test('translates epoch milliseconds if `translateTime` is `true`', async t => {
   const formattedTime = formatTime(epochMS, true)
-  t.equal(formattedTime, '17:30:00.000')
+  t.assert.strictEqual(formattedTime, '17:30:00.000')
 })
 
-tap.test('translates epoch milliseconds to UTC string given format', async t => {
+test('translates epoch milliseconds to UTC string given format', async t => {
   const formattedTime = formatTime(epochMS, 'd mmm yyyy H:MM')
-  t.equal(formattedTime, '6 Apr 2019 17:30')
+  t.assert.strictEqual(formattedTime, '6 Apr 2019 17:30')
 })
 
-tap.test('translates epoch milliseconds to SYS:STANDARD', async t => {
+test('translates epoch milliseconds to SYS:STANDARD', async t => {
   const formattedTime = formatTime(epochMS, 'SYS:STANDARD')
-  t.match(formattedTime, /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} [-+]?\d{4}/)
+  t.assert.match(formattedTime, /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} [-+]?\d{4}/)
 })
 
-tap.test('translates epoch milliseconds to SYS:<FORMAT>', async t => {
+test('translates epoch milliseconds to SYS:<FORMAT>', async t => {
   const formattedTime = formatTime(epochMS, 'SYS:d mmm yyyy H:MM')
-  t.match(formattedTime, /\d{1} \w{3} \d{4} \d{1,2}:\d{2}/)
+  t.assert.match(formattedTime, /\d{1} \w{3} \d{4} \d{1,2}:\d{2}/)
 })
 
-tap.test('passes through date string if `translateTime` is `false`', async t => {
+test('passes through date string if `translateTime` is `false`', async t => {
   const formattedTime = formatTime(dateStr)
-  t.equal(formattedTime, dateStr)
+  t.assert.strictEqual(formattedTime, dateStr)
 })
 
-tap.test('translates date string if `translateTime` is `true`', async t => {
+test('translates date string if `translateTime` is `true`', async t => {
   const formattedTime = formatTime(dateStr, true)
-  t.equal(formattedTime, '17:30:00.000')
+  t.assert.strictEqual(formattedTime, '17:30:00.000')
 })
 
-tap.test('translates date string to UTC string given format', async t => {
+test('translates date string to UTC string given format', async t => {
   const formattedTime = formatTime(dateStr, 'd mmm yyyy H:MM')
-  t.equal(formattedTime, '6 Apr 2019 17:30')
+  t.assert.strictEqual(formattedTime, '6 Apr 2019 17:30')
 })
 
-tap.test('translates date string to SYS:STANDARD', async t => {
+test('translates date string to SYS:STANDARD', async t => {
   const formattedTime = formatTime(dateStr, 'SYS:STANDARD')
-  t.match(formattedTime, /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} [-+]?\d{4}/)
+  t.assert.match(formattedTime, /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} [-+]?\d{4}/)
 })
 
-tap.test('translates date string to UTC:<FORMAT>', async t => {
+test('translates date string to UTC:<FORMAT>', async t => {
   const formattedTime = formatTime(dateStr, 'UTC:d mmm yyyy H:MM')
-  t.equal(formattedTime, '6 Apr 2019 17:30')
+  t.assert.strictEqual(formattedTime, '6 Apr 2019 17:30')
 })
 
-tap.test('translates date string to SYS:<FORMAT>', async t => {
+test('translates date string to SYS:<FORMAT>', async t => {
   const formattedTime = formatTime(dateStr, 'SYS:d mmm yyyy H:MM')
-  t.match(formattedTime, /\d{1} \w{3} \d{4} \d{1,2}:\d{2}/)
+  t.assert.match(formattedTime, /\d{1} \w{3} \d{4} \d{1,2}:\d{2}/)
 })


### PR DESCRIPTION
This PR moves `format-time.test.js` to node test.