### PR TITLE
test: move get-property-value.test.js to node test

### DIFF
--- a/lib/utils/get-property-value.test.js
+++ b/lib/utils/get-property-value.test.js
@@ -3,29 +3,29 @@
 const { test } = require('node:test')
 const getPropertyValue = require('./get-property-value')
 
-test('getPropertyValue returns the value of the property', async t => {
+test('getPropertyValue returns the value of the property', t => {
   const result = getPropertyValue({
     foo: 'bar'
   }, 'foo')
   t.assert.strictEqual(result, 'bar')
 })
 
-test('getPropertyValue returns the value of the nested property', async t => {
+test('getPropertyValue returns the value of the nested property', t => {
   const result = getPropertyValue({ extra: { foo: { value: 'bar' } } }, 'extra.foo.value')
   t.assert.strictEqual(result, 'bar')
 })
 
-test('getPropertyValue returns the value of the nested property using the array of nested property keys', async t => {
+test('getPropertyValue returns the value of the nested property using the array of nested property keys', t => {
   const result = getPropertyValue({ extra: { foo: { value: 'bar' } } }, ['extra', 'foo', 'value'])
   t.assert.strictEqual(result, 'bar')
 })
 
-test('getPropertyValue returns undefined for non-existing properties', async t => {
+test('getPropertyValue returns undefined for non-existing properties', t => {
   const result = getPropertyValue({ extra: { foo: { value: 'bar' } } }, 'extra.foo.value-2')
   t.assert.strictEqual(result, undefined)
 })
 
-test('getPropertyValue returns undefined for non-existing properties using the array of nested property keys', async t => {
+test('getPropertyValue returns undefined for non-existing properties using the array of nested property keys', t => {
   const result = getPropertyValue({ extra: { foo: { value: 'bar' } } }, ['extra', 'foo', 'value-2'])
   t.assert.strictEqual(result, undefined)
 })

--- a/lib/utils/get-property-value.test.js
+++ b/lib/utils/get-property-value.test.js
@@ -1,31 +1,31 @@
 'use strict'
 
-const tap = require('tap')
+const { test } = require('node:test')
 const getPropertyValue = require('./get-property-value')
 
-tap.test('getPropertyValue returns the value of the property', async t => {
+test('getPropertyValue returns the value of the property', async t => {
   const result = getPropertyValue({
     foo: 'bar'
   }, 'foo')
-  t.same(result, 'bar')
+  t.assert.strictEqual(result, 'bar')
 })
 
-tap.test('getPropertyValue returns the value of the nested property', async t => {
+test('getPropertyValue returns the value of the nested property', async t => {
   const result = getPropertyValue({ extra: { foo: { value: 'bar' } } }, 'extra.foo.value')
-  t.same(result, 'bar')
+  t.assert.strictEqual(result, 'bar')
 })
 
-tap.test('getPropertyValue returns the value of the nested property using the array of nested property keys', async t => {
+test('getPropertyValue returns the value of the nested property using the array of nested property keys', async t => {
   const result = getPropertyValue({ extra: { foo: { value: 'bar' } } }, ['extra', 'foo', 'value'])
-  t.same(result, 'bar')
+  t.assert.strictEqual(result, 'bar')
 })
 
-tap.test('getPropertyValue returns undefined for non-existing properties', async t => {
+test('getPropertyValue returns undefined for non-existing properties', async t => {
   const result = getPropertyValue({ extra: { foo: { value: 'bar' } } }, 'extra.foo.value-2')
-  t.same(result, undefined)
+  t.assert.strictEqual(result, undefined)
 })
 
-tap.test('getPropertyValue returns undefined for non-existing properties using the array of nested property keys', async t => {
+test('getPropertyValue returns undefined for non-existing properties using the array of nested property keys', async t => {
   const result = getPropertyValue({ extra: { foo: { value: 'bar' } } }, ['extra', 'foo', 'value-2'])
-  t.same(result, undefined)
+  t.assert.strictEqual(result, undefined)
 })


### PR DESCRIPTION
This PR moves `get-property-value.test.js` to node test