### PR TITLE
test: move handle-custom-levels-opts.test.js to node test

### DIFF
--- a/lib/utils/handle-custom-levels-opts.test.js
+++ b/lib/utils/handle-custom-levels-opts.test.js
@@ -3,17 +3,17 @@
 const { test } = require('node:test')
 const handleCustomLevelsOpts = require('./handle-custom-levels-opts')
 
-test('returns a empty object `{}` for undefined parameter', async t => {
+test('returns a empty object `{}` for undefined parameter', t => {
   const handledCustomLevel = handleCustomLevelsOpts()
   t.assert.deepStrictEqual(handledCustomLevel, {})
 })
 
-test('returns a empty object `{}` for unknown parameter', async t => {
+test('returns a empty object `{}` for unknown parameter', t => {
   const handledCustomLevel = handleCustomLevelsOpts(123)
   t.assert.deepStrictEqual(handledCustomLevel, {})
 })
 
-test('returns a filled object for string parameter', async t => {
+test('returns a filled object for string parameter', t => {
   const handledCustomLevel = handleCustomLevelsOpts('ok:10,warn:20,error:35')
   t.assert.deepStrictEqual(handledCustomLevel, {
     10: 'OK',
@@ -23,7 +23,7 @@ test('returns a filled object for string parameter', async t => {
   })
 })
 
-test('returns a filled object for object parameter', async t => {
+test('returns a filled object for object parameter', t => {
   const handledCustomLevel = handleCustomLevelsOpts({
     ok: 10,
     warn: 20,
@@ -37,7 +37,7 @@ test('returns a filled object for object parameter', async t => {
   })
 })
 
-test('defaults missing level num to first index', async t => {
+test('defaults missing level num to first index', t => {
   const result = handleCustomLevelsOpts('ok:10,info')
   t.assert.deepStrictEqual(result, {
     10: 'OK',


### PR DESCRIPTION
This PR moves `handle-custom-levels-opts.test.js` to node test