### PR TITLE
test: move index.test.js to node test

### DIFF
--- a/lib/utils/index.test.js
+++ b/lib/utils/index.test.js
@@ -7,7 +7,7 @@ const { basename } = require('node:path')
 
 test(
   'index exports exactly all non-test files excluding itself',
-  async t => {
+  t => {
     // Read all files in the `util` directory
     const files = readdirSync(__dirname)
 

--- a/lib/utils/index.test.js
+++ b/lib/utils/index.test.js
@@ -1,11 +1,11 @@
 'use strict'
 
-const tap = require('tap')
+const { test } = require('node:test')
 const index = require('./index.js')
 const { readdirSync } = require('node:fs')
 const { basename } = require('node:path')
 
-tap.test(
+test(
   'index exports exactly all non-test files excluding itself',
   async t => {
     // Read all files in the `util` directory
@@ -20,10 +20,10 @@ tap.test(
 
       if (file.endsWith('.test.js') === false && file !== 'index.js') {
         // We expect all files to be exported except…
-        t.ok(index[snakeName], `exports ${snakeName}`)
+        t.assert.ok(index[snakeName], `exports ${snakeName}`)
       } else {
         // …test files and the index file itself – those must not be exported
-        t.notOk(index[snakeName], `does not export ${snakeName}`)
+        t.assert.ok(!index[snakeName], `does not export ${snakeName}`)
       }
 
       // Remove the exported file from the index object
@@ -32,6 +32,6 @@ tap.test(
 
     // Now the index is expected to be empty, as nothing else should be
     // exported from it
-    t.same(index, {}, 'does not export anything else')
+    t.assert.deepStrictEqual(index, {}, 'does not export anything else')
   }
 )


### PR DESCRIPTION
This PR moves `index.test.js` to node test