### PR TITLE
test: move prettify-error-log.test.js to node test

### DIFF
--- a/lib/utils/prettify-error-log.test.js
+++ b/lib/utils/prettify-error-log.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const tap = require('tap')
+const { test, describe } = require('node:test')
 const prettifyErrorLog = require('./prettify-error-log')
 const colors = require('../colors')
 const {
@@ -18,13 +18,13 @@ const context = {
   objectColorizer: colors()
 }
 
-tap.test('returns string with default settings', async t => {
+test('returns string with default settings', async t => {
   const err = Error('Something went wrong')
   const str = prettifyErrorLog({ log: err, context })
-  t.ok(str.startsWith('    Error: Something went wrong'))
+  t.assert.ok(str.startsWith('    Error: Something went wrong'))
 })
 
-tap.test('returns string with custom ident', async t => {
+test('returns string with custom ident', async t => {
   const err = Error('Something went wrong')
   const str = prettifyErrorLog({
     log: err,
@@ -33,10 +33,10 @@ tap.test('returns string with custom ident', async t => {
       IDENT: '  '
     }
   })
-  t.ok(str.startsWith('  Error: Something went wrong'))
+  t.assert.ok(str.startsWith('  Error: Something went wrong'))
 })
 
-tap.test('returns string with custom eol', async t => {
+test('returns string with custom eol', async t => {
   const err = Error('Something went wrong')
   const str = prettifyErrorLog({
     log: err,
@@ -45,11 +45,11 @@ tap.test('returns string with custom eol', async t => {
       EOL: '\r\n'
     }
   })
-  t.ok(str.startsWith('    Error: Something went wrong\r\n'))
+  t.assert.ok(str.startsWith('    Error: Something went wrong\r\n'))
 })
 
-tap.test('errorProperties', t => {
-  t.test('excludes all for wildcard', async t => {
+describe('errorProperties', () => {
+  test('excludes all for wildcard', async t => {
     const err = Error('boom')
     err.foo = 'foo'
     const str = prettifyErrorLog({
@@ -59,11 +59,11 @@ tap.test('errorProperties', t => {
         errorProps: ['*']
       }
     })
-    t.ok(str.startsWith('    Error: boom'))
-    t.equal(str.includes('foo: "foo"'), false)
+    t.assert.ok(str.startsWith('    Error: boom'))
+    t.assert.strictEqual(str.includes('foo: "foo"'), false)
   })
 
-  t.test('excludes only selected properties', async t => {
+  test('excludes only selected properties', async t => {
     const err = Error('boom')
     err.foo = 'foo'
     const str = prettifyErrorLog({
@@ -73,11 +73,11 @@ tap.test('errorProperties', t => {
         errorProps: ['foo']
       }
     })
-    t.ok(str.startsWith('    Error: boom'))
-    t.equal(str.includes('foo: foo'), true)
+    t.assert.ok(str.startsWith('    Error: boom'))
+    t.assert.strictEqual(str.includes('foo: foo'), true)
   })
 
-  t.test('ignores specified properties if not present', async t => {
+  test('ignores specified properties if not present', async t => {
     const err = Error('boom')
     err.foo = 'foo'
     const str = prettifyErrorLog({
@@ -87,12 +87,12 @@ tap.test('errorProperties', t => {
         errorProps: ['foo', 'bar']
       }
     })
-    t.ok(str.startsWith('    Error: boom'))
-    t.equal(str.includes('foo: foo'), true)
-    t.equal(str.includes('bar'), false)
+    t.assert.ok(str.startsWith('    Error: boom'))
+    t.assert.strictEqual(str.includes('foo: foo'), true)
+    t.assert.strictEqual(str.includes('bar'), false)
   })
 
-  t.test('processes nested objects', async t => {
+  test('processes nested objects', async t => {
     const err = Error('boom')
     err.foo = { bar: 'bar', message: 'included' }
     const str = prettifyErrorLog({
@@ -102,11 +102,9 @@ tap.test('errorProperties', t => {
         errorProps: ['foo']
       }
     })
-    t.ok(str.startsWith('    Error: boom'))
-    t.equal(str.includes('foo: {'), true)
-    t.equal(str.includes('bar: "bar"'), true)
-    t.equal(str.includes('message: "included"'), true)
+    t.assert.ok(str.startsWith('    Error: boom'))
+    t.assert.strictEqual(str.includes('foo: {'), true)
+    t.assert.strictEqual(str.includes('bar: "bar"'), true)
+    t.assert.strictEqual(str.includes('message: "included"'), true)
   })
-
-  t.end()
 })

--- a/lib/utils/prettify-error-log.test.js
+++ b/lib/utils/prettify-error-log.test.js
@@ -18,13 +18,13 @@ const context = {
   objectColorizer: colors()
 }
 
-test('returns string with default settings', async t => {
+test('returns string with default settings', t => {
   const err = Error('Something went wrong')
   const str = prettifyErrorLog({ log: err, context })
   t.assert.ok(str.startsWith('    Error: Something went wrong'))
 })
 
-test('returns string with custom ident', async t => {
+test('returns string with custom ident', t => {
   const err = Error('Something went wrong')
   const str = prettifyErrorLog({
     log: err,
@@ -36,7 +36,7 @@ test('returns string with custom ident', async t => {
   t.assert.ok(str.startsWith('  Error: Something went wrong'))
 })
 
-test('returns string with custom eol', async t => {
+test('returns string with custom eol', t => {
   const err = Error('Something went wrong')
   const str = prettifyErrorLog({
     log: err,
@@ -49,7 +49,7 @@ test('returns string with custom eol', async t => {
 })
 
 describe('errorProperties', () => {
-  test('excludes all for wildcard', async t => {
+  test('excludes all for wildcard', t => {
     const err = Error('boom')
     err.foo = 'foo'
     const str = prettifyErrorLog({
@@ -63,7 +63,7 @@ describe('errorProperties', () => {
     t.assert.strictEqual(str.includes('foo: "foo"'), false)
   })
 
-  test('excludes only selected properties', async t => {
+  test('excludes only selected properties', t => {
     const err = Error('boom')
     err.foo = 'foo'
     const str = prettifyErrorLog({
@@ -77,7 +77,7 @@ describe('errorProperties', () => {
     t.assert.strictEqual(str.includes('foo: foo'), true)
   })
 
-  test('ignores specified properties if not present', async t => {
+  test('ignores specified properties if not present', t => {
     const err = Error('boom')
     err.foo = 'foo'
     const str = prettifyErrorLog({
@@ -92,7 +92,7 @@ describe('errorProperties', () => {
     t.assert.strictEqual(str.includes('bar'), false)
   })
 
-  test('processes nested objects', async t => {
+  test('processes nested objects', t => {
     const err = Error('boom')
     err.foo = { bar: 'bar', message: 'included' }
     const str = prettifyErrorLog({


### PR DESCRIPTION
This PR moves `prettify-error-log.test.js` to node test