### PR TITLE
test: move prettify-metadata.test.js to node test

### DIFF
--- a/lib/utils/prettify-metadata.test.js
+++ b/lib/utils/prettify-metadata.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const tap = require('tap')
+const { test } = require('node:test')
 const prettifyMetadata = require('./prettify-metadata')
 const getColorizer = require('../colors')
 const context = {
@@ -10,87 +10,87 @@ const context = {
   }
 }
 
-tap.test('returns `undefined` if no metadata present', async t => {
+test('returns `undefined` if no metadata present', t => {
   const str = prettifyMetadata({ log: {}, context })
-  t.equal(str, undefined)
+  t.assert.strictEqual(str, undefined)
 })
 
-tap.test('works with only `name` present', async t => {
+test('works with only `name` present', t => {
   const str = prettifyMetadata({ log: { name: 'foo' }, context })
-  t.equal(str, '(foo)')
+  t.assert.strictEqual(str, '(foo)')
 })
 
-tap.test('works with only `pid` present', async t => {
+test('works with only `pid` present', t => {
   const str = prettifyMetadata({ log: { pid: '1234' }, context })
-  t.equal(str, '(1234)')
+  t.assert.strictEqual(str, '(1234)')
 })
 
-tap.test('works with only `hostname` present', async t => {
+test('works with only `hostname` present', t => {
   const str = prettifyMetadata({ log: { hostname: 'bar' }, context })
-  t.equal(str, '(on bar)')
+  t.assert.strictEqual(str, '(on bar)')
 })
 
-tap.test('works with only `name` & `pid` present', async t => {
+test('works with only `name` & `pid` present', t => {
   const str = prettifyMetadata({ log: { name: 'foo', pid: '1234' }, context })
-  t.equal(str, '(foo/1234)')
+  t.assert.strictEqual(str, '(foo/1234)')
 })
 
-tap.test('works with only `name` & `hostname` present', async t => {
+test('works with only `name` & `hostname` present', t => {
   const str = prettifyMetadata({ log: { name: 'foo', hostname: 'bar' }, context })
-  t.equal(str, '(foo on bar)')
+  t.assert.strictEqual(str, '(foo on bar)')
 })
 
-tap.test('works with only `pid` & `hostname` present', async t => {
+test('works with only `pid` & `hostname` present', t => {
   const str = prettifyMetadata({ log: { pid: '1234', hostname: 'bar' }, context })
-  t.equal(str, '(1234 on bar)')
+  t.assert.strictEqual(str, '(1234 on bar)')
 })
 
-tap.test('works with only `name`, `pid`, & `hostname` present', async t => {
+test('works with only `name`, `pid`, & `hostname` present', t => {
   const str = prettifyMetadata({ log: { name: 'foo', pid: '1234', hostname: 'bar' }, context })
-  t.equal(str, '(foo/1234 on bar)')
+  t.assert.strictEqual(str, '(foo/1234 on bar)')
 })
 
-tap.test('works with only `name` & `caller` present', async t => {
+test('works with only `name` & `caller` present', t => {
   const str = prettifyMetadata({ log: { name: 'foo', caller: 'baz' }, context })
-  t.equal(str, '(foo) <baz>')
+  t.assert.strictEqual(str, '(foo) <baz>')
 })
 
-tap.test('works with only `pid` & `caller` present', async t => {
+test('works with only `pid` & `caller` present', t => {
   const str = prettifyMetadata({ log: { pid: '1234', caller: 'baz' }, context })
-  t.equal(str, '(1234) <baz>')
+  t.assert.strictEqual(str, '(1234) <baz>')
 })
 
-tap.test('works with only `hostname` & `caller` present', async t => {
+test('works with only `hostname` & `caller` present', t => {
   const str = prettifyMetadata({ log: { hostname: 'bar', caller: 'baz' }, context })
-  t.equal(str, '(on bar) <baz>')
+  t.assert.strictEqual(str, '(on bar) <baz>')
 })
 
-tap.test('works with only `name`, `pid`, & `caller` present', async t => {
+test('works with only `name`, `pid`, & `caller` present', t => {
   const str = prettifyMetadata({ log: { name: 'foo', pid: '1234', caller: 'baz' }, context })
-  t.equal(str, '(foo/1234) <baz>')
+  t.assert.strictEqual(str, '(foo/1234) <baz>')
 })
 
-tap.test('works with only `name`, `hostname`, & `caller` present', async t => {
+test('works with only `name`, `hostname`, & `caller` present', t => {
   const str = prettifyMetadata({ log: { name: 'foo', hostname: 'bar', caller: 'baz' }, context })
-  t.equal(str, '(foo on bar) <baz>')
+  t.assert.strictEqual(str, '(foo on bar) <baz>')
 })
 
-tap.test('works with only `caller` present', async t => {
+test('works with only `caller` present', t => {
   const str = prettifyMetadata({ log: { caller: 'baz' }, context })
-  t.equal(str, '<baz>')
+  t.assert.strictEqual(str, '<baz>')
 })
 
-tap.test('works with only `pid`, `hostname`, & `caller` present', async t => {
+test('works with only `pid`, `hostname`, & `caller` present', t => {
   const str = prettifyMetadata({ log: { pid: '1234', hostname: 'bar', caller: 'baz' }, context })
-  t.equal(str, '(1234 on bar) <baz>')
+  t.assert.strictEqual(str, '(1234 on bar) <baz>')
 })
 
-tap.test('works with all four present', async t => {
+test('works with all four present', t => {
   const str = prettifyMetadata({ log: { name: 'foo', pid: '1234', hostname: 'bar', caller: 'baz' }, context })
-  t.equal(str, '(foo/1234 on bar) <baz>')
+  t.assert.strictEqual(str, '(foo/1234 on bar) <baz>')
 })
 
-tap.test('uses prettifiers from passed prettifiers object', async t => {
+test('uses prettifiers from passed prettifiers object', t => {
   const prettifiers = {
     name (input) {
       return input.toUpperCase()
@@ -112,10 +112,10 @@ tap.test('uses prettifiers from passed prettifiers object', async t => {
       colorizer: { colors: {} }
     }
   })
-  t.equal(str, '(JOE/1234__ on BAR) <BAZ>')
+  t.assert.strictEqual(str, '(JOE/1234__ on BAR) <BAZ>')
 })
 
-tap.test('uses colorizer from passed context to colorize metadata', async t => {
+test('uses colorizer from passed context to colorize metadata', t => {
   const prettifiers = {
     name (input, _key, _log, { colors }) {
       return colors.blue(input)
@@ -145,5 +145,5 @@ tap.test('uses colorizer from passed context to colorize metadata', async t => {
   const colorizedCaller = colorizer.colors.cyan(log.caller)
   const expected = `(${colorizedName}/${colorizedPid} on ${colorizedHostname}) <${colorizedCaller}>`
 
-  t.equal(result, expected)
+  t.assert.strictEqual(result, expected)
 })


### PR DESCRIPTION
This PR moves `prettify-metadata.test.js` to node test