### PR TITLE
fix: allow esm import for isColorSupported

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -225,9 +225,10 @@ declare namespace PinoPretty {
   type ColorizerFactory = typeof colorizerFactory;
   type PrettyFactory = typeof prettyFactory;
   type Build = typeof build;
-  type isColorSupported = typeof Colorette.isColorSupported;
 
-  export { build, PinoPretty, PrettyOptions, PrettyStream, colorizerFactory, prettyFactory, isColorSupported };
+  // @ts-ignore
+  export const isColorSupported = Colorette.isColorSupported;
+  export { build, PinoPretty, PrettyOptions, PrettyStream, colorizerFactory, prettyFactory };
 }
 
 export = PinoPretty;


### PR DESCRIPTION
Fix for #615 

Typescript definitions file was exporting a type rather than a value.

Not 100% sure on this--it works for me, but the IDE keeps highlighting an error (which I've marked as ts-ignore)