### PR TITLE
fix: missing `property` on objectColorizer

### DIFF
--- a/lib/colors.js
+++ b/lib/colors.js
@@ -39,7 +39,7 @@ function resolveCustomColoredColorizer (customColors) {
 
       return agg
     },
-    { default: white, message: cyan, greyMessage: gray }
+    { default: white, message: cyan, greyMessage: gray, property: magenta }
   )
 }
 
@@ -85,6 +85,7 @@ function customColoredColorizerFactory (customColors, useOnlyCustomProps) {
   }
   customColoredColorizer.colors = availableColors
   customColoredColorizer.message = customColoredColorizer.message || customColored.message
+  customColoredColorizer.property = customColoredColorizer.property || customColored.property
   customColoredColorizer.greyMessage = customColoredColorizer.greyMessage || customColored.greyMessage
 
   return customColoredColorizer

--- a/lib/utils/prettify-object.test.js
+++ b/lib/utils/prettify-object.test.js
@@ -164,3 +164,30 @@ test('works with single level properties', t => {
   })
   t.assert.strictEqual(str, `    ${colorizer.colors.magenta('foo')}: "bar"\n`)
 })
+
+test('works with customColors', t => {
+  const colorizer = colors(true, [])
+  t.assert.doesNotThrow(() => {
+    prettifyObject({
+      log: { foo: 'bar' },
+      context: {
+        ...context,
+        objectColorizer: colorizer,
+        colorizer
+      }
+    })
+  })
+})
+
+test('customColors gets applied', t => {
+  const colorizer = colors(true, [['property', 'green']])
+  const str = prettifyObject({
+    log: { foo: 'bar' },
+    context: {
+      ...context,
+      objectColorizer: colorizer,
+      colorizer
+    }
+  })
+  t.assert.strictEqual(str, `    ${colorizer.colors.green('foo')}: "bar"\n`)
+})


### PR DESCRIPTION
When `customColors` option is specified to `pino-pretty`, the following error is thrown while prettifying object:

```
TypeError: objectColorizer.property is not a function
                    at .../pino-pretty/lib/utils/prettify-object.js:95:44
                    at Array.forEach (<anonymous>)
                    at prettifyObject (.../pino-pretty/lib/utils/prettify-object.js:83:27)
                    at TestContext.<anonymous> (.../pino-pretty/lib/utils/prettify-object.test.js:170:15)
                    at Test.runInAsyncScope (node:async_hooks:214:14)
                    at Test.run (node:internal/test_runner/test:1106:25)
                    at Test.processPendingSubtests (node:internal/test_runner/test:788:18)
                    at Test.postRun (node:internal/test_runner/test:1235:19)
                    at Test.run (node:internal/test_runner/test:1163:12)
                    at async Test.processPendingSubtests (node:internal/test_runner/test:788:7)
```
It seems the `property` field is not properly set on the `objectColorizer`. 
This PR addresses this issue. 

Fixes #617