### PR TITLE
Support "true" and "false" for boolean options

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,6 +103,52 @@ const defaultOptions = {
 }
 
 /**
+ * Normalizes a value to a boolean if it's the string "true" or "false".
+ * Otherwise returns the value unchanged.
+ *
+ * @param {any} value The value to normalize
+ * @returns {any} The normalized value
+ */
+function normalizeBoolean (value) {
+  if (value === 'true') return true
+  if (value === 'false') return false
+  return value
+}
+
+/**
+ * Normalizes boolean options by converting "true" and "false" strings to booleans.
+ *
+ * @param {PinoPrettyOptions} options The options to normalize
+ * @returns {PinoPrettyOptions} The normalized options
+ */
+function normalizeBooleanOptions (options) {
+  const normalized = { ...options }
+  const booleanOptions = [
+    'colorize',
+    'colorizeObjects',
+    'crlf',
+    'hideObject',
+    'levelFirst',
+    'singleLine',
+    'useOnlyCustomProps'
+  ]
+
+  for (const key of booleanOptions) {
+    if (key in normalized) {
+      normalized[key] = normalizeBoolean(normalized[key])
+    }
+  }
+
+  // translateTime can be boolean or string (format string)
+  // Only normalize if it's exactly "true" or "false"
+  if ('translateTime' in normalized && (normalized.translateTime === 'true' || normalized.translateTime === 'false')) {
+    normalized.translateTime = normalizeBoolean(normalized.translateTime)
+  }
+
+  return normalized
+}
+
+/**
  * Processes the supplied options and returns a function that accepts log data
  * and produces a prettified log string.
  *
@@ -110,7 +156,9 @@ const defaultOptions = {
  * @returns {LogPrettifierFunc}
  */
 function prettyFactory (options) {
-  const context = parseFactoryOptions(Object.assign({}, defaultOptions, options))
+  const mergedOptions = Object.assign({}, defaultOptions, options)
+  const normalizedOptions = normalizeBooleanOptions(mergedOptions)
+  const context = parseFactoryOptions(normalizedOptions)
   return pretty.bind({ ...context, context })
 }
 

--- a/lib/utils/parse-factory-options.js
+++ b/lib/utils/parse-factory-options.js
@@ -81,9 +81,7 @@ function parseFactoryOptions (options) {
     translateTime
   } = options
   const errorProps = options.errorProps.split(',')
-  const useOnlyCustomProps = typeof options.useOnlyCustomProps === 'boolean'
-    ? options.useOnlyCustomProps
-    : (options.useOnlyCustomProps === 'true')
+  const useOnlyCustomProps = options.useOnlyCustomProps
   const customLevels = handleCustomLevelsOpts(options.customLevels)
   const customLevelNames = handleCustomLevelsNamesOpts(options.customLevels)
   const getLevelLabelData = handleLevelLabelData(useOnlyCustomProps, customLevels, customLevelNames)

--- a/test/boolean-options.test.js
+++ b/test/boolean-options.test.js
@@ -1,0 +1,228 @@
+'use strict'
+
+process.env.TZ = 'UTC'
+
+const os = require('node:os')
+const { describe, test, beforeEach, afterEach } = require('node:test')
+const { Writable } = require('node:stream')
+const pino = require('pino')
+
+const pinoPretty = require('..')
+const _prettyFactory = pinoPretty.prettyFactory
+
+// Disable pino warnings
+process.removeAllListeners('warning')
+
+function prettyFactory (opts) {
+  if (!opts) {
+    opts = { colorize: false }
+  } else if (!Object.prototype.hasOwnProperty.call(opts, 'colorize')) {
+    opts.colorize = false
+  }
+  return _prettyFactory(opts)
+}
+
+// All dates are computed from 'Fri, 30 Mar 2018 17:35:28 GMT'
+const epoch = 1522431328992
+const formattedEpoch = '17:35:28.992'
+const pid = process.pid
+const hostname = os.hostname()
+
+describe('boolean options string conversion', () => {
+  beforeEach(() => {
+    Date.originalNow = Date.now
+    Date.now = () => epoch
+  })
+  afterEach(() => {
+    Date.now = Date.originalNow
+    delete Date.originalNow
+  })
+
+  test('accepts string "true" and "false" for all boolean options', async (t) => {
+    const logLine = `{"level":30,"time":${epoch},"msg":"foo","pid":${pid},"hostname":"${hostname}"}`
+
+    const testCases = [
+      {
+        option: 'colorize',
+        testValue: (value) => {
+          return new Promise((resolve) => {
+            const pretty = prettyFactory({ colorize: value })
+            const stream = new Writable({
+              write (chunk, enc, cb) {
+                const formatted = pretty(chunk.toString())
+                if (value === 'true') {
+                  t.assert.strictEqual(
+                    formatted,
+                    `[${formattedEpoch}] \u001B[32mINFO\u001B[39m (${pid}): \u001B[36mfoo\u001B[39m\n`
+                  )
+                } else {
+                  t.assert.strictEqual(
+                    formatted,
+                    `[${formattedEpoch}] INFO (${pid}): foo\n`
+                  )
+                }
+                cb()
+                resolve()
+              }
+            })
+            const log = pino({}, stream)
+            log.info('foo')
+          })
+        }
+      },
+      {
+        option: 'crlf',
+        testValue: (value) => {
+          return Promise.resolve().then(() => {
+            const pretty = prettyFactory({ crlf: value })
+            const formatted = pretty(logLine)
+            if (value === 'true') {
+              t.assert.strictEqual(formatted, `[${formattedEpoch}] INFO (${pid}): foo\r\n`)
+            } else {
+              t.assert.strictEqual(formatted, `[${formattedEpoch}] INFO (${pid}): foo\n`)
+            }
+          })
+        }
+      },
+      {
+        option: 'levelFirst',
+        testValue: (value) => {
+          return Promise.resolve().then(() => {
+            const pretty = prettyFactory({ levelFirst: value })
+            const formatted = pretty(logLine)
+            if (value === 'true') {
+              t.assert.strictEqual(formatted, `INFO [${formattedEpoch}] (${pid}): foo\n`)
+            } else {
+              t.assert.strictEqual(formatted, `[${formattedEpoch}] INFO (${pid}): foo\n`)
+            }
+          })
+        }
+      },
+      {
+        option: 'hideObject',
+        testValue: (value) => {
+          return new Promise((resolve) => {
+            const pretty = prettyFactory({ hideObject: value })
+            const stream = new Writable({
+              write (chunk, enc, cb) {
+                const formatted = pretty(chunk.toString())
+                if (value === 'true') {
+                  t.assert.strictEqual(formatted, `[${formattedEpoch}] INFO (${pid}): foo\n`)
+                } else {
+                  t.assert.match(formatted, /foo:\s*"bar"/)
+                }
+                cb()
+                resolve()
+              }
+            })
+            const log = pino({}, stream)
+            log.info({ foo: 'bar' }, 'foo')
+          })
+        }
+      },
+      {
+        option: 'singleLine',
+        testValue: (value) => {
+          return new Promise((resolve) => {
+            const pretty = prettyFactory({ singleLine: value })
+            const stream = new Writable({
+              write (chunk, enc, cb) {
+                const formatted = pretty(chunk.toString())
+                if (value === 'true') {
+                  t.assert.match(formatted, /{"foo":"bar"}/)
+                  t.assert.doesNotMatch(formatted, /\n\s+foo:/)
+                } else {
+                  t.assert.match(formatted, /\n\s+foo:/)
+                }
+                cb()
+                resolve()
+              }
+            })
+            const log = pino({}, stream)
+            log.info({ foo: 'bar' }, 'foo')
+          })
+        }
+      },
+      {
+        option: 'colorizeObjects',
+        testValue: (value) => {
+          return new Promise((resolve) => {
+            const pretty = prettyFactory({ colorize: true, singleLine: true, colorizeObjects: value })
+            const stream = new Writable({
+              write (chunk, enc, cb) {
+                const formatted = pretty(chunk.toString())
+                if (value === 'true') {
+                  t.assert.strictEqual(
+                    formatted,
+                    `[${formattedEpoch}] \u001B[32mINFO\u001B[39m (${pid}): \u001B[36mfoo\u001B[39m \u001B[90m{"foo":"bar"}\u001B[39m\n`
+                  )
+                } else {
+                  t.assert.strictEqual(
+                    formatted,
+                    `[${formattedEpoch}] \u001B[32mINFO\u001B[39m (${pid}): \u001B[36mfoo\u001B[39m {"foo":"bar"}\n`
+                  )
+                }
+                cb()
+                resolve()
+              }
+            })
+            const log = pino({}, stream)
+            log.info({ foo: 'bar' }, 'foo')
+          })
+        }
+      },
+      {
+        option: 'translateTime',
+        testValue: (value) => {
+          return Promise.resolve().then(() => {
+            const pretty = prettyFactory({ translateTime: value })
+            const formatted = pretty(logLine)
+            if (value === 'true') {
+              t.assert.strictEqual(formatted, `[${formattedEpoch}] INFO (${pid}): foo\n`)
+            } else {
+              t.assert.match(formatted, new RegExp(`\\[${epoch}\\] INFO \\(${pid}\\): foo\\n`))
+            }
+          })
+        }
+      },
+      {
+        option: 'useOnlyCustomProps',
+        testValue: (value) => {
+          return new Promise((resolve) => {
+            const pretty = prettyFactory({ useOnlyCustomProps: value, customLevels: 'custom:25' })
+            const stream = new Writable({
+              write (chunk, enc, cb) {
+                const formatted = pretty(chunk.toString())
+                if (value === 'true') {
+                  t.assert.match(formatted, /USERLVL/)
+                } else {
+                  t.assert.match(formatted, /INFO/)
+                }
+                cb()
+                resolve()
+              }
+            })
+            const log = pino({ customLevels: { custom: 35 } }, stream)
+            if (value === 'true') {
+              log.custom('test')
+            } else {
+              log.info('test')
+            }
+          })
+        }
+      }
+    ]
+
+    for (const testCase of testCases) {
+      await testCase.testValue('false')
+      await testCase.testValue('true')
+    }
+  })
+
+  test('translateTime still accepts format strings when not "true" or "false"', (t) => {
+    t.plan(1)
+    const pretty = prettyFactory({ translateTime: 'UTC:yyyy-mm-dd HH:MM:ss' })
+    const formatted = pretty(`{"level":30,"time":${epoch},"msg":"foo","pid":${pid},"hostname":"${hostname}"}`)
+    t.assert.match(formatted, /\[2018-03-30 17:35:28\] INFO/)
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "lib": [ "es2015" ],
     "module": "commonjs",
     "noEmit": true,
-    "strict": true
+    "strict": true,
+    "esModuleInterop": true
   },
   "include": [
     "./test/types/pino-pretty.test.d.ts",


### PR DESCRIPTION
In Platformatic's Watt we instrument `pino-pretty` from a JSON config file, that accepts placeholders like `{COLORIZE_LOGS}` from env variables.

This will interpolate the value as string `"true"` or `"false"` for boolean options.

With this PR, `pino-pretty` can accept those string values, and they are converted to boolean before creating the instance.

Tests are written for each boolean values.