### PR TITLE
chore: upgrade borp to v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@jsumners/assert-match": "^1.0.0",
     "@jsumners/line-reporter": "^1.0.1",
     "@types/node": "^25.0.3",
-    "borp": "^0.21.0",
+    "borp": "^1.0.0",
     "eslint": "^9.39.1",
     "fastbench": "^1.0.1",
     "neostandard": "^0.12.2",


### PR DESCRIPTION
Proposal:

- Upgrade `borp` dependency from `^0.21.0` to `^1.0.0` ( see here: https://github.com/mcollina/borp/releases/tag/v1.0.0 )