### PR TITLE
chore: remove legacy `.eslintrc` config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,0 @@
-{
-  "extends": [
-    "standard"
-  ],
-  "rules": {
-    "no-var": "off"
-  }
-}


### PR DESCRIPTION
The file is unused and redundant since flat config is used now.