### PR TITLE
fix: strip unsafe terminal control characters

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -23,6 +23,7 @@ module.exports = {
   prettifyObject: require('./prettify-object.js'),
   prettifyTime: require('./prettify-time.js'),
   splitPropertyKey: require('./split-property-key.js'),
+  stripUnsafeControlChars: require('./strip-unsafe-control-chars.js'),
   getLevelLabelData: require('./get-level-label-data')
 }
 

--- a/lib/utils/prettify-error-log.js
+++ b/lib/utils/prettify-error-log.js
@@ -9,6 +9,7 @@ const {
 const isObject = require('./is-object')
 const joinLinesWithIndentation = require('./join-lines-with-indentation')
 const prettifyObject = require('./prettify-object')
+const stripUnsafeControlChars = require('./strip-unsafe-control-chars')
 
 /**
  * @typedef {object} PrettifyErrorLogParams
@@ -32,7 +33,7 @@ function prettifyErrorLog ({ log, context }) {
     errorProps: errorProperties,
     messageKey
   } = context
-  const stack = log.stack
+  const stack = stripUnsafeControlChars(log.stack)
   const joinedLines = joinLinesWithIndentation({ input: stack, ident, eol })
   let result = `${ident}${joinedLines}${eol}`
 
@@ -50,6 +51,7 @@ function prettifyErrorLog ({ log, context }) {
     for (let i = 0; i < propertiesToPrint.length; i += 1) {
       const key = propertiesToPrint[i]
       if (key in log === false) continue
+      const safeKey = stripUnsafeControlChars(key)
       if (isObject(log[key])) {
         // The nested object may have "logger" type keys but since they are not
         // at the root level of the object being processed, we want to print them.
@@ -62,10 +64,11 @@ function prettifyErrorLog ({ log, context }) {
             IDENT: ident + ident
           }
         })
-        result = `${result}${ident}${key}: {${eol}${prettifiedObject}${ident}}${eol}`
+        result = `${result}${ident}${safeKey}: {${eol}${prettifiedObject}${ident}}${eol}`
         continue
       }
-      result = `${result}${ident}${key}: ${log[key]}${eol}`
+      const value = stripUnsafeControlChars(log[key])
+      result = `${result}${ident}${safeKey}: ${value}${eol}`
     }
   }
 

--- a/lib/utils/prettify-error-log.test.js
+++ b/lib/utils/prettify-error-log.test.js
@@ -24,6 +24,13 @@ test('returns string with default settings', t => {
   t.assert.ok(str.startsWith('    Error: Something went wrong'))
 })
 
+test('strips unsafe control characters from the stack', t => {
+  const err = Error('Something went wrong')
+  err.stack = 'Error: bad\u001B[2J\n    at location\u009B[3J'
+  const str = prettifyErrorLog({ log: err, context })
+  t.assert.strictEqual(str, '    Error: bad[2J\n        at location[3J\n')
+})
+
 test('returns string with custom ident', t => {
   const err = Error('Something went wrong')
   const str = prettifyErrorLog({
@@ -106,5 +113,31 @@ describe('errorProperties', () => {
     t.assert.strictEqual(str.includes('foo: {'), true)
     t.assert.strictEqual(str.includes('bar: "bar"'), true)
     t.assert.strictEqual(str.includes('message: "included"'), true)
+  })
+
+  test('strips unsafe control characters from primitive property names and values', t => {
+    const err = Error('boom')
+    err['detail\u001B[2J'] = 'hidden\u009B[3J'
+    const str = prettifyErrorLog({
+      log: err,
+      context: {
+        ...context,
+        errorProps: ['*']
+      }
+    })
+    t.assert.strictEqual(str.includes('detail[2J: hidden[3J'), true)
+  })
+
+  test('strips unsafe control characters after primitive properties are coerced', t => {
+    const err = Error('boom')
+    err.detail = ['hidden\u001B[2J']
+    const str = prettifyErrorLog({
+      log: err,
+      context: {
+        ...context,
+        errorProps: ['detail']
+      }
+    })
+    t.assert.strictEqual(str.includes('detail: hidden[2J'), true)
   })
 })

--- a/lib/utils/prettify-error.js
+++ b/lib/utils/prettify-error.js
@@ -3,6 +3,7 @@
 module.exports = prettifyError
 
 const joinLinesWithIndentation = require('./join-lines-with-indentation')
+const stripUnsafeControlChars = require('./strip-unsafe-control-chars')
 
 /**
  * @typedef {object} PrettifyErrorParams
@@ -11,6 +12,7 @@ const joinLinesWithIndentation = require('./join-lines-with-indentation')
  *  custom prettifier, that should be pre-applied as well.
  * @property {string} ident The indentation sequence to use.
  * @property {string} eol The EOL sequence to use.
+ * @property {boolean} [sanitizeStack=true] Whether to sanitize the decoded stack.
  */
 
 /**
@@ -20,10 +22,11 @@ const joinLinesWithIndentation = require('./join-lines-with-indentation')
  *
  * @returns {string}
  */
-function prettifyError ({ keyName, lines, eol, ident }) {
+function prettifyError ({ keyName, lines, eol, ident, sanitizeStack = true }) {
   let result = ''
   const joinedLines = joinLinesWithIndentation({ input: lines, ident, eol })
-  const splitLines = `${ident}${keyName}: ${joinedLines}${eol}`.split(eol)
+  const safeKeyName = stripUnsafeControlChars(keyName)
+  const splitLines = `${ident}${safeKeyName}: ${joinedLines}${eol}`.split(eol)
 
   for (let j = 0; j < splitLines.length; j += 1) {
     if (j !== 0) result += eol
@@ -36,7 +39,9 @@ function prettifyError ({ keyName, lines, eol, ident }) {
         const indentSize = /^\s*/.exec(line)[0].length + 4
         const indentation = ' '.repeat(indentSize)
         const stackMessage = matches[2]
-        result += matches[1] + eol + indentation + JSON.parse(stackMessage).replace(/\n/g, eol + indentation)
+        const parsedStack = JSON.parse(stackMessage)
+        const stack = sanitizeStack ? stripUnsafeControlChars(parsedStack) : parsedStack
+        result += matches[1] + eol + indentation + stack.replace(/\n/g, eol + indentation)
       } else {
         result += line
       }

--- a/lib/utils/prettify-error.test.js
+++ b/lib/utils/prettify-error.test.js
@@ -11,3 +11,15 @@ test('prettifies error', t => {
   const prettyError = prettifyError({ keyName: 'errorKey', lines, ident: '    ', eol: '\n' })
   t.assert.match(prettyError, /\s*errorKey: {\n\s*"stack":[\s\S]*"message": "Bad error!"/)
 })
+
+test('strips unsafe control characters from an error stack', t => {
+  const lines = stringifySafe({
+    stack: 'Error: bad\u001B[2J\n    at location\u009B[3J',
+    message: 'bad'
+  }, null, 2)
+
+  const prettyError = prettifyError({ keyName: 'errorKey', lines, ident: '    ', eol: '\n' })
+  t.assert.strictEqual(prettyError.includes('\u001B'), false)
+  t.assert.strictEqual(prettyError.includes('\u009B'), false)
+  t.assert.match(prettyError, /Error: bad\[2J\n\s+at location\[3J/)
+})

--- a/lib/utils/prettify-message.js
+++ b/lib/utils/prettify-message.js
@@ -8,6 +8,7 @@ const {
 
 const getPropertyValue = require('./get-property-value')
 const interpretConditionals = require('./interpret-conditionals')
+const stripUnsafeControlChars = require('./strip-unsafe-control-chars')
 
 /**
  * @typedef {object} PrettifyMessageParams
@@ -52,7 +53,7 @@ function prettifyMessage ({ log, context }) {
         const value = getPropertyValue(log, p1)
         return value !== undefined ? value : ''
       })
-    return colorizer.message(message)
+    return colorizer.message(stripUnsafeControlChars(message))
   }
   if (messageFormat && typeof messageFormat === 'function') {
     const msg = messageFormat(log, messageKey, levelLabel, { colors: colorizer.colors })
@@ -60,5 +61,5 @@ function prettifyMessage ({ log, context }) {
   }
   if (messageKey in log === false) return undefined
   if (typeof log[messageKey] !== 'string' && typeof log[messageKey] !== 'number' && typeof log[messageKey] !== 'boolean') return undefined
-  return colorizer.message(log[messageKey])
+  return colorizer.message(stripUnsafeControlChars(log[messageKey]))
 }

--- a/lib/utils/prettify-message.test.js
+++ b/lib/utils/prettify-message.test.js
@@ -50,6 +50,15 @@ test('returns colorized value for color colorizer', t => {
   t.assert.strictEqual(str, '\u001B[36mfoo\u001B[39m')
 })
 
+test('strips unsafe control characters before colorizing a message', t => {
+  const colorizer = getColorizer(true)
+  const str = prettifyMessage({
+    log: { msg: 'before\t\u001B[2Jafter\nnext\u009B[3J' },
+    context: { ...context, colorizer }
+  })
+  t.assert.strictEqual(str, '\u001B[36mbefore\t[2Jafter\nnext[3J\u001B[39m')
+})
+
 test('returns colorized value for color colorizer for alternate `messageKey`', t => {
   const colorizer = getColorizer(true)
   const str = prettifyMessage({
@@ -62,6 +71,14 @@ test('returns colorized value for color colorizer for alternate `messageKey`', t
 test('returns message formatted by `messageFormat` option', t => {
   const str = prettifyMessage({
     log: { msg: 'foo', context: 'appModule' },
+    context: { ...context, messageFormat: '{context} - {msg}' }
+  })
+  t.assert.strictEqual(str, 'appModule - foo')
+})
+
+test('strips unsafe control characters substituted by a string `messageFormat`', t => {
+  const str = prettifyMessage({
+    log: { msg: 'foo\u0007', context: 'app\u007FModule' },
     context: { ...context, messageFormat: '{context} - {msg}' }
   })
   t.assert.strictEqual(str, 'appModule - foo')

--- a/lib/utils/prettify-metadata.js
+++ b/lib/utils/prettify-metadata.js
@@ -2,6 +2,8 @@
 
 module.exports = prettifyMetadata
 
+const stripUnsafeControlChars = require('./strip-unsafe-control-chars')
+
 /**
  * @typedef {object} PrettifyMetadataParams
  * @property {object} log The log that may or may not contain metadata to
@@ -30,13 +32,13 @@ function prettifyMetadata ({ log, context }) {
     if (log.name) {
       line += prettifiers.name
         ? prettifiers.name(log.name, 'name', log, { colors: colorizer.colors })
-        : log.name
+        : stripUnsafeControlChars(log.name)
     }
 
     if (log.pid) {
       const prettyPid = prettifiers.pid
         ? prettifiers.pid(log.pid, 'pid', log, { colors: colorizer.colors })
-        : log.pid
+        : stripUnsafeControlChars(log.pid)
       if (log.name && log.pid) {
         line += '/' + prettyPid
       } else {
@@ -49,7 +51,7 @@ function prettifyMetadata ({ log, context }) {
       // the leading space.
       const prettyHostname = prettifiers.hostname
         ? prettifiers.hostname(log.hostname, 'hostname', log, { colors: colorizer.colors })
-        : log.hostname
+        : stripUnsafeControlChars(log.hostname)
 
       line += `${line === '(' ? 'on' : ' on'} ${prettyHostname}`
     }
@@ -60,7 +62,7 @@ function prettifyMetadata ({ log, context }) {
   if (log.caller) {
     const prettyCaller = prettifiers.caller
       ? prettifiers.caller(log.caller, 'caller', log, { colors: colorizer.colors })
-      : log.caller
+      : stripUnsafeControlChars(log.caller)
 
     line += `${line === '' ? '' : ' '}<${prettyCaller}>`
   }

--- a/lib/utils/prettify-metadata.test.js
+++ b/lib/utils/prettify-metadata.test.js
@@ -90,6 +90,27 @@ test('works with all four present', t => {
   t.assert.strictEqual(str, '(foo/1234 on bar) <baz>')
 })
 
+test('strips unsafe control characters from default metadata', t => {
+  const str = prettifyMetadata({
+    log: {
+      name: 'foo\u001B[2J',
+      pid: '1234\u0007',
+      hostname: 'bar\u009B[3J',
+      caller: 'baz\u007F'
+    },
+    context
+  })
+  t.assert.strictEqual(str, '(foo[2J/1234 on bar[3J) <baz>')
+})
+
+test('strips unsafe control characters after metadata values are coerced', t => {
+  const str = prettifyMetadata({
+    log: { name: ['foo\u001B[2J'] },
+    context
+  })
+  t.assert.strictEqual(str, '(foo[2J)')
+})
+
 test('uses prettifiers from passed prettifiers object', t => {
   const prettifiers = {
     name (input) {

--- a/lib/utils/prettify-object.js
+++ b/lib/utils/prettify-object.js
@@ -9,6 +9,7 @@ const {
 const stringifySafe = require('fast-safe-stringify')
 const joinLinesWithIndentation = require('./join-lines-with-indentation')
 const prettifyError = require('./prettify-error')
+const stripUnsafeControlChars = require('./strip-unsafe-control-chars')
 
 /**
  * @typedef {object} PrettifyObjectParams
@@ -92,20 +93,22 @@ function prettifyObject ({
       lines = lines.replace(/\\\\/gi, '\\')
 
       const joinedLines = joinLinesWithIndentation({ input: lines, ident, eol })
-      result += `${ident}${objectColorizer.property(keyName)}:${joinedLines.startsWith(eol) ? '' : ' '}${joinedLines}${eol}`
+      const safeKeyName = stripUnsafeControlChars(keyName)
+      result += `${ident}${objectColorizer.property(safeKeyName)}:${joinedLines.startsWith(eol) ? '' : ' '}${joinedLines}${eol}`
     })
   }
 
   // Errors
   Object.entries(errors).forEach(([keyName, keyValue]) => {
     // custom prettifiers are already applied above, so we can skip it now
-    const lines = typeof customPrettifiers[keyName] === 'function'
+    const hasCustomPrettifier = typeof customPrettifiers[keyName] === 'function'
+    const lines = hasCustomPrettifier
       ? keyValue
       : stringifySafe(keyValue, null, 2)
 
     if (lines === undefined) return
 
-    result += prettifyError({ keyName, lines, eol, ident })
+    result += prettifyError({ keyName, lines, eol, ident, sanitizeStack: !hasCustomPrettifier })
   })
 
   return result

--- a/lib/utils/prettify-object.test.js
+++ b/lib/utils/prettify-object.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { test } = require('node:test')
+const stringifySafe = require('fast-safe-stringify')
 const colors = require('../colors')
 const prettifyObject = require('./prettify-object')
 const {
@@ -25,6 +26,11 @@ test('returns empty string if no properties present', t => {
 test('works with single level properties', t => {
   const str = prettifyObject({ log: { foo: 'bar' }, context })
   t.assert.strictEqual(str, '    foo: "bar"\n')
+})
+
+test('strips unsafe control characters from property names', t => {
+  const str = prettifyObject({ log: { 'foo\u001B[2J\u009B[3J': 'bar' }, context })
+  t.assert.strictEqual(str, '    foo[2J[3J: "bar"\n')
 })
 
 test('works with multiple level properties', t => {
@@ -136,6 +142,24 @@ test('errors skips prettifiers', t => {
     }
   })
   t.assert.strictEqual(str.includes('err: is_err'), true)
+})
+
+test('preserves control characters produced by a custom error prettifier', t => {
+  const colorizer = colors(true)
+  const customPrettifiers = {
+    err: (_value, _key, _log, { colors }) => stringifySafe({
+      stack: colors.red('Error: boom')
+    }, null, 2)
+  }
+  const str = prettifyObject({
+    log: { err: Error('boom') },
+    context: {
+      ...context,
+      colorizer,
+      customPrettifiers
+    }
+  })
+  t.assert.strictEqual(str.includes(colorizer.colors.red('Error: boom')), true)
 })
 
 test('errors skips prettifying if no lines are present', t => {

--- a/lib/utils/prettify-time.js
+++ b/lib/utils/prettify-time.js
@@ -3,6 +3,7 @@
 module.exports = prettifyTime
 
 const formatTime = require('./format-time')
+const stripUnsafeControlChars = require('./strip-unsafe-control-chars')
 
 /**
  * @typedef {object} PrettifyTimeParams
@@ -38,5 +39,5 @@ function prettifyTime ({ log, context }) {
   if (time === null) return undefined
   const output = translateFormat ? formatTime(time, translateFormat) : time
 
-  return prettifier ? prettifier(output) : `[${output}]`
+  return prettifier ? prettifier(output) : `[${stripUnsafeControlChars(output)}]`
 }

--- a/lib/utils/prettify-time.test.js
+++ b/lib/utils/prettify-time.test.js
@@ -211,6 +211,28 @@ test('works with epoch as a number or string', (t) => {
   t.assert.strictEqual(invalid, '[2 days ago]')
 })
 
+test('strips unsafe control characters from default time output', t => {
+  const str = prettifyTime({
+    log: { time: 'invalid\u001B[2J\u009B[3J' },
+    context: {
+      ...context,
+      translateTime: true
+    }
+  })
+  t.assert.strictEqual(str, '[invalid[2J[3J]')
+})
+
+test('strips unsafe control characters after time values are coerced', t => {
+  const str = prettifyTime({
+    log: { time: ['invalid\u001B[2J'] },
+    context: {
+      ...context,
+      translateTime: false
+    }
+  })
+  t.assert.strictEqual(str, '[invalid[2J]')
+})
+
 test('uses custom prettifier', t => {
   const str = prettifyTime({
     log: { time: 0 },
@@ -224,4 +246,19 @@ test('uses custom prettifier', t => {
     }
   })
   t.assert.strictEqual(str, 'done')
+})
+
+test('preserves control characters produced by a custom time prettifier', t => {
+  const str = prettifyTime({
+    log: { time: 0 },
+    context: {
+      ...context,
+      customPrettifiers: {
+        time () {
+          return '\u001B[31mdone\u001B[39m'
+        }
+      }
+    }
+  })
+  t.assert.strictEqual(str, '\u001B[31mdone\u001B[39m')
 })

--- a/lib/utils/strip-unsafe-control-chars.js
+++ b/lib/utils/strip-unsafe-control-chars.js
@@ -1,0 +1,18 @@
+'use strict'
+
+module.exports = stripUnsafeControlChars
+
+// These control characters are the exact values this utility must remove.
+// eslint-disable-next-line no-control-regex
+const unsafeControlChars = /[\u0000-\u0008\u000B-\u001F\u007F-\u009F]/g
+
+/**
+ * Removes control characters that can alter terminal output while preserving
+ * tabs and newlines used for readable formatting.
+ *
+ * @param {*} input The value to sanitize.
+ * @returns {string} The sanitized string.
+ */
+function stripUnsafeControlChars (input) {
+  return String(input).replace(unsafeControlChars, '')
+}

--- a/lib/utils/strip-unsafe-control-chars.test.js
+++ b/lib/utils/strip-unsafe-control-chars.test.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const { test } = require('node:test')
+const stripUnsafeControlChars = require('./strip-unsafe-control-chars')
+
+test('coerces values before stripping unsafe control characters', t => {
+  const value = ['before\t\u001B[2J\nafter\u009B[3J']
+  t.assert.strictEqual(stripUnsafeControlChars(value), 'before\t[2J\nafter[3J')
+})


### PR DESCRIPTION
## Summary

- strip unsafe C0 control characters (except tab and newline), DEL, and C1 controls from untrusted fields rendered by the default formatters
- cover messages, string `messageFormat` substitutions, nested and legacy error output, metadata, multiline property names, and default timestamp output
- coerce default-rendered values before stripping so arrays and objects cannot reintroduce controls during later string conversion
- preserve pino-pretty's own color codes and output produced by trusted function formatters and custom prettifiers
- retain the existing pass-through behavior for malformed and unknown lines

This is development-tool hardening under pino-pretty's documented usage model, not a vulnerability classification.

## TDD

- added three initial regression tests and confirmed they failed before the message/error fix
- added six first-review cases and confirmed they failed before hardening the remaining default formatter paths
- added four second-review coercion cases and confirmed they failed before coercing values in the shared stripping helper
- retained tests proving trusted custom formatter color output is not stripped

## Testing

- `npm run ci` — 363 tests passed; lint, coverage, type tests, and package checks passed
- end-to-end CLI check confirmed injected ESC bytes are absent from formatted message output
