### PR TITLE
feat: support CLI options via environment variables

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -101,6 +101,19 @@ node app.js | pino-pretty
 - `--singleLine` (`-S`): Print each log message on a single line (errors will still be multi-line)
 - `--config`: Specify a path to a config file containing the pino-pretty options.  pino-pretty will attempt to read from a `.pino-prettyrc` in your current directory (`process.cwd`) if not specified
 
+<a id="clienv"></a>
+### CLI Environment Variables
+
+The same options can be set via environment variables using `SCREAMING_SNAKE_CASE`
+names that match the long option names. Boolean options accept values such as
+`true` / `false` (not only `1` / `0`):
+
+```sh
+node app.js | SINGLE_LINE=true COLORIZE=true pino-pretty
+```
+
+CLI arguments override config files, which override environment variables.
+
 <a id="integration"></a>
 ## Programmatic Integration
 

--- a/bin.js
+++ b/bin.js
@@ -33,6 +33,32 @@ const joycon = new JoyCon({
   stopDir: path.dirname(process.cwd())
 })
 
+// Map SCREAMING_SNAKE env vars to camelCase CLI option names.
+// Example: SINGLE_LINE=true COLORIZE=true pino-pretty
+const ENV_OPTION_MAP = {
+  COLORIZE: 'colorize',
+  COLORIZE_OBJECTS: 'colorizeObjects',
+  CONFIG: 'config',
+  CRLF: 'crlf',
+  CUSTOM_COLORS: 'customColors',
+  CUSTOM_LEVELS: 'customLevels',
+  ERROR_LIKE_OBJECT_KEYS: 'errorLikeObjectKeys',
+  ERROR_PROPS: 'errorProps',
+  HIDE_OBJECT: 'hideObject',
+  IGNORE: 'ignore',
+  INCLUDE: 'include',
+  LEVEL_FIRST: 'levelFirst',
+  LEVEL_KEY: 'levelKey',
+  LEVEL_LABEL: 'levelLabel',
+  MESSAGE_FORMAT: 'messageFormat',
+  MESSAGE_KEY: 'messageKey',
+  MINIMUM_LEVEL: 'minimumLevel',
+  SINGLE_LINE: 'singleLine',
+  TIMESTAMP_KEY: 'timestampKey',
+  TRANSLATE_TIME: 'translateTime',
+  USE_ONLY_CUSTOM_PROPS: 'useOnlyCustomProps'
+}
+
 const cmd = minimist(process.argv.slice(2))
 
 if (cmd.h || cmd.help) {
@@ -72,9 +98,10 @@ if (cmd.h || cmd.help) {
 
   // Remove default values
   opts = filter(opts, value => value !== DEFAULT_VALUE)
-  const config = loadConfig(opts.config)
-  // Override config with cli options
-  opts = Object.assign({}, config, opts)
+  const envOpts = loadEnvOptions()
+  const config = loadConfig(opts.config || envOpts.config)
+  // Precedence: CLI > config file > environment variables
+  opts = Object.assign({}, envOpts, config, opts)
   // set defaults
   opts.errorLikeObjectKeys = opts.errorLikeObjectKeys || 'err,error'
   opts.errorProps = opts.errorProps || ''
@@ -86,6 +113,16 @@ if (cmd.h || cmd.help) {
   /* istanbul ignore next */
   if (!process.stdin.isTTY && !fs.fstatSync(process.stdin.fd).isFile()) {
     process.once('SIGINT', function noOp () {})
+  }
+
+  function loadEnvOptions () {
+    const result = {}
+    for (const [envName, optionName] of Object.entries(ENV_OPTION_MAP)) {
+      if (Object.prototype.hasOwnProperty.call(process.env, envName)) {
+        result[optionName] = process.env[envName]
+      }
+    }
+    return result
   }
 
   function loadConfig (configPath) {

--- a/help/help.txt
+++ b/help/help.txt
@@ -65,4 +65,7 @@
     - Loads options from a config file
     $ cat log | pino-pretty --config=/path/to/config.json
 
+    - Set options via environment variables (SCREAMING_SNAKE_CASE of the long option name)
+    $ cat log | SINGLE_LINE=true COLORIZE=true pino-pretty
+
   

--- a/test/cli-env.test.js
+++ b/test/cli-env.test.js
@@ -1,0 +1,80 @@
+'use strict'
+
+process.env.TZ = 'UTC'
+
+const path = require('node:path')
+const { spawn } = require('node:child_process')
+const { describe, test } = require('node:test')
+const { once } = require('./helper')
+
+const bin = require.resolve(path.join(__dirname, '..', 'bin.js'))
+const logLine = '{"level":30,"time":1522431328992,"msg":"hello world","pid":42,"hostname":"foo"}\n'
+const baseEnv = { TERM: 'dumb', TZ: 'UTC' }
+const formattedEpoch = '17:35:28.992'
+
+describe('cli environment variables', () => {
+  test('SINGLE_LINE=true enables single-line object output', async (t) => {
+    t.plan(1)
+    const logLineWithExtra = JSON.stringify(Object.assign(JSON.parse(logLine), {
+      extra: {
+        foo: 'bar',
+        number: 42
+      }
+    })) + '\n'
+
+    const child = spawn(process.argv[0], [bin], {
+      env: { ...baseEnv, SINGLE_LINE: 'true' }
+    })
+    child.on('error', t.assert.fail)
+    const endPromise = once(child.stdout, 'data', (data) => {
+      t.assert.strictEqual(data.toString(), `[${formattedEpoch}] INFO (42): hello world {"extra":{"foo":"bar","number":42}}\n`)
+    })
+    child.stdin.end(logLineWithExtra)
+    await endPromise
+    t.after(() => child.kill())
+  })
+
+  test('LEVEL_FIRST=true flips epoch and level', async (t) => {
+    t.plan(1)
+    const child = spawn(process.argv[0], [bin], {
+      env: { ...baseEnv, LEVEL_FIRST: 'true' }
+    })
+    child.on('error', t.assert.fail)
+    const endPromise = once(child.stdout, 'data', (data) => {
+      t.assert.strictEqual(data.toString(), `INFO [${formattedEpoch}] (42): hello world\n`)
+    })
+    child.stdin.end(logLine)
+    await endPromise
+    t.after(() => child.kill())
+  })
+
+  test('CLI -i overrides IGNORE environment variable', async (t) => {
+    t.plan(1)
+    const child = spawn(process.argv[0], [bin, '-i', 'time'], {
+      env: { ...baseEnv, IGNORE: 'pid,hostname' }
+    })
+    child.on('error', t.assert.fail)
+    const endPromise = once(child.stdout, 'data', (data) => {
+      // CLI ignore=time wins over env ignore=pid,hostname, so pid/hostname remain.
+      t.assert.strictEqual(data.toString(), 'INFO (42 on foo): hello world\n')
+    })
+    child.stdin.end(logLine)
+    await endPromise
+    t.after(() => child.kill())
+  })
+
+  test('COLORIZE=true is accepted as a boolean env value', async (t) => {
+    t.plan(1)
+    const child = spawn(process.argv[0], [bin], {
+      env: { ...baseEnv, COLORIZE: 'true', TERM: 'xterm-256color' }
+    })
+    child.on('error', t.assert.fail)
+    const endPromise = once(child.stdout, 'data', (data) => {
+      const output = data.toString()
+      t.assert.ok(output.includes('\u001b['), 'expected ANSI color sequences in output')
+    })
+    child.stdin.end(logLine)
+    await endPromise
+    t.after(() => child.kill())
+  })
+})


### PR DESCRIPTION
## Summary
- Allow setting the same CLI options through SCREAMING_SNAKE_CASE environment variables (for example `SINGLE_LINE=true COLORIZE=true`)
- CLI flags still win over config files, which still win over env vars
- Document the behavior in the README and help text

Fixes #554

## Test plan
- [x] `npm test`
- [x] `npm run lint`
- [ ] Manual check: `echo '{"level":30,"time":1,"msg":"hi","pid":1,"hostname":"x","extra":{"a":1}}' | SINGLE_LINE=true pino-pretty`