### PR TITLE
fix: substitute conditional messageFormat values literally

### DIFF
--- a/lib/utils/interpret-conditionals.js
+++ b/lib/utils/interpret-conditionals.js
@@ -33,7 +33,11 @@ function interpretConditionals (messageFormat, log) {
   function replacer (_, key, value) {
     const propertyValue = getPropertyValue(log, key)
     if (propertyValue && value.includes(key)) {
-      return value.replace(new RegExp('{' + key + '}', 'g'), propertyValue)
+      /* The key is matched, and the value inserted, literally: a key may contain
+         characters that are special in a regular expression (e.g. the `.` used to
+         delimit nested keys), and a logged value may contain `$` sequences that
+         would otherwise be interpreted as replacement patterns. */
+      return value.replaceAll(`{${key}}`, () => propertyValue)
     } else {
       return ''
     }

--- a/lib/utils/interpret-conditionals.test.js
+++ b/lib/utils/interpret-conditionals.test.js
@@ -82,3 +82,28 @@ test('interpretConditionals removes empty lines from removed conditionals', t =>
   const log = fastCopy(logData)
   t.assert.strictEqual(interpretConditionals('{msg}\n{if foo}{foo}{end}\n{level}', log), '{msg}\n{level}')
 })
+
+test('interpretConditionals does not interpret `$` sequences in the property value', t => {
+  const log = { msg: 'a $& b' }
+  t.assert.strictEqual(interpretConditionals('{if msg}{msg}{end}', log), 'a $& b')
+})
+
+test('interpretConditionals preserves every `$` replacement pattern in the property value', t => {
+  for (const msg of ['$$', '$&', '$`', "$'", '$1', '$<name>', '100$$']) {
+    const log = { msg }
+    t.assert.strictEqual(interpretConditionals('{if msg}{msg}{end}', log), msg)
+  }
+})
+
+test('interpretConditionals does not treat the property key as a regular expression', t => {
+  const log = { 'we(ird': 'value' }
+  t.assert.strictEqual(interpretConditionals('{if we(ird}{we(ird}{end}', log), 'value')
+})
+
+test('interpretConditionals matches the delimiter in a nested key literally', t => {
+  const log = { data1: { data2: 'bar' } }
+  t.assert.strictEqual(
+    interpretConditionals('{if data1.data2}{data1.data2} {data1Xdata2}{end}', log),
+    'bar {data1Xdata2}'
+  )
+})


### PR DESCRIPTION
### The problem

When a value is inserted into a `{if key}...{end}` block, `interpretConditionals` uses a string replacement:

```js
return value.replace(new RegExp('{' + key + '}', 'g'), propertyValue)
```

That line interpolates untrusted input into both halves of `String.prototype.replace`, which causes two distinct bugs.

**1. `$` sequences in the logged value are interpreted as replacement patterns.**

```js
const { prettyFactory } = require('pino-pretty')

const conditional = prettyFactory({ colorize: false, messageFormat: '{if msg}{msg}{end}' })
const plain = prettyFactory({ colorize: false, messageFormat: '{msg}' })

const log = (msg) => JSON.stringify({ level: 30, time: 1, msg })
```

| `msg` | `{if msg}{msg}{end}` | `{msg}` (expected) |
|---|---|---|
| `100$$` | `100$` | `100$$` |
| ``a $` b`` | `a b` | ``a $` b`` |
| `a $& b` | `a a $& b b` | `a $& b` |

`$$` collapses to a single `$`, ``$` `` and `$'` are replaced by the text around the match, and `$&` re-inserts the `{msg}` placeholder — which `prettifyMessage` then expands a second time, duplicating the value. Values like these turn up in practice in prices, shell snippets, and query strings.

**2. The key is compiled as a regular expression.**

The `.` that delimits a nested key matches any character, so an unrelated placeholder can be substituted with the wrong value:

```js
// log = { data1: { data2: 'bar' } }
interpretConditionals('{if data1.data2}{data1.data2} {data1Xdata2}{end}', log)
// actual:   'bar bar'
// expected: 'bar {data1Xdata2}'
```

And a key containing other special characters throws while formatting a log line:

```js
// log = { 'we(ird': 'value' }
interpretConditionals('{if we(ird}{we(ird}{end}', log)
// SyntaxError: Invalid regular expression: /{we(ird}/g: Unterminated group
```

### The fix

Match the placeholder and insert the value literally, via a string search and a function replacer. This is what the non-conditional path in `prettifyMessage` already does — it replaces through a function, which is why `{msg}` handles all of the cases above correctly today. The two paths now agree.

The `propertyValue && value.includes(key)` guard is unchanged, so which blocks are kept or dropped is not affected.

### Verification

Four tests added to `lib/utils/interpret-conditionals.test.js`, each failing before the change: `$` sequences preserved, every `$` replacement pattern round-tripped, a key with regex metacharacters no longer throwing, and the nested-key delimiter matched literally.

- `npm test` — 367 passed, 0 failed (363 before, plus the 4 new)
- `npm run ci` — `eslint` clean, `borp --check-coverage` passing, `tstyche` + `attw --pack` clean
